### PR TITLE
Fix/rpc class

### DIFF
--- a/lib/js/rpc/RpcMessage.js
+++ b/lib/js/rpc/RpcMessage.js
@@ -79,10 +79,6 @@ class RpcMessage extends RpcStruct {
         return this;
     }
 
-    getParameters() {
-        return this.store.parameters;
-    }
-
     getBulkData() {
         return this._bulkData;
     }

--- a/lib/js/rpc/RpcStruct.js
+++ b/lib/js/rpc/RpcStruct.js
@@ -51,9 +51,7 @@ class RpcStruct {
         if (value === null) {
             delete this._parameters[key];
         } else {
-            this._parameters.push({
-                [key]: value
-            });
+            this._parameters[key] = value;
         }
 
         return this;


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
These bugs were found when attempting to test #14 

##### Bug Fixes
_parameters was being treated as an array with the `push` method when storing a key-value pair. 

RpcMessage.getParameters() tries to access a store member variable which does not exist. The logic for getParameters is already taken care of in the superclass RpcStruct, so this method isn't needed anyway.

Extra time is needed to check for additional bugs.
