### PR TITLE
Check for jsonData content before sending to the json unmarshaller

### DIFF
--- a/generator/templates/RpcCreator_template.js
+++ b/generator/templates/RpcCreator_template.js
@@ -27,9 +27,11 @@ import { BinaryFrameHeader } from './../protocol/BinaryFrameHeader.js';
         const functionName = FunctionID.keyForValue(functionId);
         const bulkData = binaryFrameHeader.getBulkData();
         const jsonData = binaryFrameHeader.getJsonData();
-        const params = {
-            parameters: JsonRpcMarshaller.unmarshall(jsonData),
-        };
+        const params = {};
+        // not-empty object check
+        if (Object.keys(jsonData).length !== 0) {
+            params.parameters = JsonRpcMarshaller.unmarshall(jsonData);
+        }
 
         switch (functionId) {
             {%- for item in cases %}

--- a/lib/js/src/rpc/RpcCreator.js
+++ b/lib/js/src/rpc/RpcCreator.js
@@ -203,9 +203,11 @@ class RpcCreator {
         const functionName = FunctionID.keyForValue(functionId);
         const bulkData = binaryFrameHeader.getBulkData();
         const jsonData = binaryFrameHeader.getJsonData();
-        const params = {
-            parameters: JsonRpcMarshaller.unmarshall(jsonData),
-        };
+        const params = {};
+        // not-empty object check
+        if (Object.keys(jsonData).length !== 0) {
+            params.parameters = JsonRpcMarshaller.unmarshall(jsonData);
+        }
 
         switch (functionId) {
             case FunctionID.RegisterAppInterface:


### PR DESCRIPTION
Fixes #132 

This PR is **ready** for review.

### Summary
Adds a check for whether the jsonData has any content before being sent to the JSON marshaller.  The OnAudioPassThru notification has nothing in its json payload, which is what caused the JSON parse error. 

ex. send this rpc: 
```    
const rpc = new SDL.rpc.messages.PerformAudioPassThru()
        .setSamplingRate(SDL.rpc.enums.SamplingRate.SamplingRate_44KHZ)
        .setMaxDuration(1)
        .setBitsPerSample(SDL.rpc.enums.BitsPerSample.BitsPerSample_16_BIT)
        .setAudioType(SDL.rpc.enums.AudioType.PCM)
```