### PR TITLE
Check minimum protocol version against target before finishing connec…

### DIFF
--- a/lib/js/src/manager/lifecycle/LifecycleManager.js
+++ b/lib/js/src/manager/lifecycle/LifecycleManager.js
@@ -99,7 +99,12 @@ class LifecycleManager {
         const sessionListener = new SdlSessionListener();
         sessionListener.setOnProtocolSessionStarted((serviceType, sessionID, version, correlationID, hashID, isEncrypted) => {
             // Session has been started
-            // TODO check min protocol spec version
+            if (this._minimumProtocolVersion !== null && this._minimumProtocolVersion.isNewerThan(this.getProtocolVersion()) === 1) {
+                console.warn(`Disconnecting from head unit, the configured minimum protocol version ${this._minimumProtocolVersion} is greater than the supported protocol version ${this.getProtocolVersion()}`);
+                this._sdlSession.endService(serviceType, this._sdlSession.getSessionId());
+                return this._cleanProxy();
+            }
+
             if (serviceType === ServiceType.RPC) {
                 if (this._appConfig !== null && this._appConfig !== undefined) {
                     // TODO call prepare on config to make sure it is satisfactory
@@ -126,6 +131,14 @@ class LifecycleManager {
         });
 
         return sessionListener;
+    }
+
+    /**
+     * Get the current protocol version
+     * @return {Version} 
+    */
+    getProtocolVersion () {
+        return this._sdlSession.getProtocolVersion();
     }
 
     /**


### PR DESCRIPTION
Fixes #138 

This PR is **ready** for review.

### Summary
Adds a check for whether the minimum protocol version is higher than the one received. The app will refuse to continue with the connection process if this is true.

ex: `appConfig.setMinimumProtocolVersion(new SDL.util.Version().fromString("99.99.99"));`