### PR TITLE
Fixed incorrect rejection of protocol version 5.2.0 when handling aut…

### DIFF
--- a/lib/js/src/protocol/SdlProtocolBase.js
+++ b/lib/js/src/protocol/SdlProtocolBase.js
@@ -415,7 +415,7 @@ class SdlProtocolBase {
                     this._protocolVersion = new Version(5, 0, 0);
                 }
 
-                if (this._protocolVersion.isNewerThan(new Version(5, 2, 0)) && this._sdlProtocolListener !== null) {
+                if ((this._protocolVersion.isNewerThan(new Version(5, 2, 0)) >= 0) && this._sdlProtocolListener !== null) {
                     this._sdlProtocolListener.onAuthTokenReceived(
                         sdlPacket.getTag(ControlFrameTags.RPC.StartServiceACK.AUTH_TOKEN)
                     );


### PR DESCRIPTION

Fixes #137 

This PR is **ready** for review.

### Summary
Fixed a check where SDL Protocol Version 5.2.0 was being incorrectly rejected and not allowing the Auth Token to be set in the SDL Manager.
