### PR TITLE
Bugfix/transport close

### DIFF
--- a/lib/js/src/protocol/SdlProtocolBase.js
+++ b/lib/js/src/protocol/SdlProtocolBase.js
@@ -529,6 +529,9 @@ class SdlProtocolBase {
         const version = this._protocolVersion.getMajor();
         const sdlPacket = SdlPacketFactory.createEndSession(serviceType, sessionId, messageID, version, hashID);
         this.sendPacket(sdlPacket);
+        if (this._transportManager !== null) {
+            this._transportManager.stop();
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #142 

This PR is **ready** for review.

### Summary
Closes the transport connection on dispose. This will close for client applications such as TCP and WS client apps. For WS servers, the connection would stay open.