### PR TITLE
Change the condition for proxy being connected so that HMI NONE can b…

### DIFF
--- a/lib/js/src/manager/permission/PermissionManagerBase.js
+++ b/lib/js/src/manager/permission/PermissionManagerBase.js
@@ -57,7 +57,6 @@ class PermissionManagerBase extends SubManagerBase {
             }
             const previousHmiLevel = this._currentHmiLevel;
             this._currentHmiLevel = notification.getHmiLevel();
-            this._checkState();
             this._notifyListeners(this._currentPermissionItems, previousHmiLevel, this._currentPermissionItems, this._currentHmiLevel);
         };
         this._lifecycleManager.addRpcListener(FunctionID.OnHMIStatus, this._onHMIStatusListener);
@@ -97,9 +96,8 @@ class PermissionManagerBase extends SubManagerBase {
      * @return {Promise}
     */
     async start () {
+        this._transitionToState(SubManagerBase.READY);
         await super.start();
-        this._checkState();
-        return Promise.resolve(this.getState() === SubManagerBase.READY || this.getState() === SubManagerBase.LIMITED);
     }
 
     /**
@@ -118,16 +116,6 @@ class PermissionManagerBase extends SubManagerBase {
      */
     getRequiresEncryption () {
         return this._encryptionRequiredRpcs.length > 0;
-    }
-
-    /**
-     * Transition to READY state if the conditions are appropriate
-     * @private
-     */
-    _checkState () {
-        if (this.getState() === SubManagerBase.SETTING_UP && this._currentHmiLevel !== null) {
-            this._transitionToState(SubManagerBase.READY);
-        }
     }
 
     /**


### PR DESCRIPTION
Fixes #147 

This PR is **ready** for review.

### Summary
The bugfix should be responsible for allowing app icons to be set for an app before it is in HMI FULL.

This change causes the proxy to be considered connected when a RAI response is received, as opposed to also waiting for OnHMIStatus before invoked proxy connected. This means that now the sub managers are able to attach listeners to listen for HMI NONE, which the permission manager needs in order to consider its status to be READY.

Note that this isn't the only solution, and that there are other possibilities to consider:
1. Don't have the permission manager wait for an HMI NONE that will never come as part of the condition to be considered READY
2. Invoke SDL Manager's _onReady only when the file manager is ready, which is the manager that is responsible for setting the app icon. The other managers won't be ready until HMI FULL, but the dependency on whether the file manager is ready is all that's necessary to set the app icon.

A combination of the three solutions are also possible. Open to suggestions