### PR TITLE
Don't use caching when using queryCapability, and use output of getCa…

### DIFF
--- a/lib/js/src/manager/SystemCapabilityManager.js
+++ b/lib/js/src/manager/SystemCapabilityManager.js
@@ -390,18 +390,11 @@ class SystemCapabilityManager extends SubManagerBase {
     }
 
     /**
-     * Sends a request to core for the capability, instead of only checking cached capabilities
+     * Sends a request to core for the capability, instead of checking cached capabilities
      * @param {SystemCapabilityType} systemCapabilityType
      * @return {Promise} - Promise returning either the capability Object or null if not found
     */
     async queryCapability (systemCapabilityType) {
-        const capability = this.getCapability(systemCapabilityType);
-        if (capability !== undefined && capability !== null) {
-            return capability;
-        }
-
-        // no cached capabilities. go out to get them
-
         // don't bother getting a capability if it isn't queryable
         const getCapabilityMethodName = this._getCapabilityMethodForType(systemCapabilityType);
         if (getCapabilityMethodName === null) {
@@ -433,7 +426,8 @@ class SystemCapabilityManager extends SubManagerBase {
         // invoke the correct get capability method
         const retrievedCapability = response.getSystemCapability()[getCapabilityMethodName]();
         this.setCapability(systemCapabilityType, retrievedCapability);
-        return retrievedCapability;
+        // get the capability back through this method, because it may have changed the output
+        return this.getCapability(systemCapabilityType, retrievedCapability);
     }
 
     /**


### PR DESCRIPTION
Fixes #150 

This PR is **ready** for review.

### Summary
Removes the step of getting the cached value and stopping early for queryCapability. Also makes sure to call getCapability after the query, as getCapability may modify the stored values of capabilities such as with app services. This will make calling either function return consistent values