### PR TITLE
Allow commit to return a boolean as to whether the update is successful

### DIFF
--- a/lib/js/src/manager/screen/ScreenManagerBase.js
+++ b/lib/js/src/manager/screen/ScreenManagerBase.js
@@ -386,15 +386,16 @@ class ScreenManagerBase extends SubManagerBase {
 
     /**
      * Send the updates that were started after beginning the transaction
-     * @return {Promise}
+     * @return {Promise} - Resolves to Boolean: whether the commit is a success
      */
-    async commit (listener) {
+    async commit () {
         this._softButtonManager.setBatchUpdates(false);
         this._textAndGraphicManager.setBatchUpdates(false);
-        return await Promise.all([
-            this._softButtonManager.update(),
-            this._textAndGraphicManager.update(),
-        ]);
+        // order matters!
+        const success1 = await this._softButtonManager.update();
+        const success2 = await this._textAndGraphicManager.update();
+
+        return success1 && success2;
     }
 }
 

--- a/lib/js/src/manager/screen/SoftButtonManagerBase.js
+++ b/lib/js/src/manager/screen/SoftButtonManagerBase.js
@@ -278,23 +278,28 @@ class SoftButtonManagerBase extends SubManagerBase {
 
     /**
      * Add a new task to send a new Show RPC to reflect the changes
+     * @return {Promise} - Resolves to Boolean: whether the update is successful
     */
     update () {
-        // don't continue if the manager is in batch mode
-        if (this._batchingUpdates) {
-            return;
-        }
-        this._addTask(this._updateTask());
+        return new Promise((resolve, reject) => {
+            // don't continue if the manager is in batch mode
+            if (this._batchingUpdates) {
+                resolve(false);
+            }
+            this._addTask(this._updateTask(resolve));
+        });
     }
 
     /**
      * Update the SoftButtonManger by sending a new Show RPC to reflect the changes
+     * @private
+     * @param {function} listener - A function to invoke when the update task is complete once it runs
      * @return {function} - An async function that returns after this update is done
     */
-    _updateTask () {
+    _updateTask (listener) {
         return async (taskQueue) => {
-            // empty the queue out the safe way
-            taskQueue.splice(0, taskQueue.length);
+            // can't empty the queue now. we need all tasks to run in case one of them is ran by commit()
+            // taskQueue.splice(0, taskQueue.length);
 
             // Send Show RPC with soft buttons representing the current state for the soft button objects
             const show = new Show()
@@ -306,6 +311,7 @@ class SoftButtonManagerBase extends SubManagerBase {
                 // The images don't yet exist on the head unit, or we cannot use images, send a text update if possible, otherwise, don't send anything yet
                 const textOnlySoftButtons = this._createTextSoftButtonsForCurrentState();
                 if (textOnlySoftButtons === null) {
+                    listener(true);
                     return;
                 }
                 show.setSoftButtons(textOnlySoftButtons);
@@ -319,6 +325,7 @@ class SoftButtonManagerBase extends SubManagerBase {
             if (!response.getSuccess()) {
                 console.error(response);
             }
+            listener(response.getSuccess()); // send whether the update is a success
         };
     }
 

--- a/lib/js/src/manager/screen/TextAndGraphicManagerBase.js
+++ b/lib/js/src/manager/screen/TextAndGraphicManagerBase.js
@@ -105,25 +105,28 @@ class TextAndGraphicManagerBase extends SubManagerBase {
 
     /**
      * Conditionally applies a Show update based on what has been set in the internal state
-     * @private
+     * @return {Promise} - Resolves to Boolean: whether the update is successful
     */
     async update () {
-        // don't continue if the manager is in batch mode
-        if (this._batchingUpdates) {
-            return;
-        }
-        this._addTask(this._sdlUpdate());
+        return new Promise((resolve, reject) => {
+            // don't continue if the manager is in batch mode
+            if (this._batchingUpdates) {
+                resolve(false);
+            }
+            this._addTask(this._sdlUpdate(resolve));
+        });
     }
 
     /**
      * Determines what needs to be done to send a valid Show method
      * @private
+     * @param {function} listener - A function to invoke when the update task is complete once it runs
      * @return {function} - An async function that returns after this update is done
     */
-    _sdlUpdate () {
+    _sdlUpdate (listener) {
         return async (taskQueue) => {
-            // empty the queue out the safe way
-            taskQueue.splice(0, taskQueue.length);
+            // can't empty the queue now. we need all tasks to run in case one of them is ran by commit()
+            // taskQueue.splice(0, taskQueue.length);
 
             // Updating Text and Graphics
             let fullShow = new Show();
@@ -133,22 +136,25 @@ class TextAndGraphicManagerBase extends SubManagerBase {
 
             fullShow = this._assembleShowImages(this._assembleShowText(fullShow));
 
+            let updateSuccess = false;
+
             if (!this._shouldUpdatePrimaryImage() && !this._shouldUpdateSecondaryImage()) {
                 // No Images to send, only sending text
-                await this._sendShow(this._extractTextFromShow(fullShow));
+                updateSuccess = await this._sendShow(this._extractTextFromShow(fullShow));
             } else if (!this._sdlArtworkNeedsUpload(this._primaryGraphic) &&
                 (this._secondaryGraphic === this._blankArtwork || !this._sdlArtworkNeedsUpload(this._secondaryGraphic))) {
                 // Images already uploaded, sending full update
                 // The files to be updated are already uploaded, send the full show immediately
-                await this._sendShow(fullShow);
+                updateSuccess = await this._sendShow(fullShow);
             } else {
                 // Images need to be uploaded, sending text and uploading images
                 const success = await this._uploadImages();
                 if (!success) {
                     fullShow = this._extractTextFromShow(fullShow);
                 }
-                await this._sendShow(fullShow);
+                updateSuccess = await this._sendShow(fullShow);
             }
+            listener(updateSuccess); // report show success status
         };
     }
 
@@ -156,7 +162,7 @@ class TextAndGraphicManagerBase extends SubManagerBase {
      * Sends the Show RPC
      * @private
      * @param {Show} show
-     * @return {Promise}
+     * @return {Promise} - Resolves to a Boolean
     */
     async _sendShow (show) {
         if (this._softButtonManager !== null) {
@@ -168,6 +174,7 @@ class TextAndGraphicManagerBase extends SubManagerBase {
         if (response.getSuccess()) {
             this._updateCurrentScreenDataState(show);
         }
+        return response.getSuccess();
     }
 
     /**


### PR DESCRIPTION
Fixes #153 

This PR is **ready** for review.

### Summary
Has the screen manager return a boolean for commit success status. Also requires the update methods of the text and graphic manager and the soft button manager to have a boolean return. The clearing of the task queue has been removed for now, to avoid the case where a task called by a commit() is cleared, which may result in a forever-hanging promise.