### PR TITLE
Example websocket app shouldn't dispose of the connection

### DIFF
--- a/examples/node/hello-sdl/AppClient.js
+++ b/examples/node/hello-sdl/AppClient.js
@@ -159,23 +159,6 @@ class AppClient {
             await this._sleep(2000);
             softButtonObjects[0].transitionToNextState();
             await this._sleep(2000);
-
-            const count = 3;
-            for (let i = 0; i < count; i++) {
-                const showCountdown = new SDL.rpc.messages.Show();
-                showCountdown.setMainField1(`Exiting in ${(count - i).toString()}`)
-                    .setMainField2('')
-                    .setMainField3('');
-
-                this._sdlManager.sendRpc(showCountdown); // don't wait for a response
-
-                await this._sleep();
-            }
-
-            // tear down the app
-            await this._sdlManager.sendRpc(new SDL.rpc.messages.UnregisterAppInterface());
-
-            this._sdlManager.dispose();
         }
     }
 


### PR DESCRIPTION
Fixes #154 

This PR is **ready** for review.

### Testing Plan
Run the example app in /node/hello-sdl and observe that it does not count down until disconnects like the other example apps.

### Summary
Example websocket no longer disposes of its server and does not send UnregisterAppInterface. There is also no countdown displayed as part of the app.
