### PR TITLE
Bugfix/example apps

### DIFF
--- a/examples/js/hello-sdl/index.html
+++ b/examples/js/hello-sdl/index.html
@@ -36,11 +36,11 @@
     <script src='./SDL.min.js'></script>
 
     <script>
+        const filePath = './test_icon_1.png';
         class HelloSdl {
             constructor () {
                 const appId = 'hello-js';
                 const fileName = `${appId}_icon`;
-                this._filePath = './test_icon_1.png';
                 const file = new SDL.manager.file.filetypes.SdlFile()
                     .setName(fileName)
                     .setFilePath(this._filePath)

--- a/examples/js/hello-sdl/index.html
+++ b/examples/js/hello-sdl/index.html
@@ -39,10 +39,11 @@
         class HelloSdl {
             constructor () {
                 const appId = 'hello-js';
-                const fileName = `${appId}_icon.gif`;
+                const fileName = `${appId}_icon`;
+                this._filePath = './test_icon_1.png';
                 const file = new SDL.manager.file.filetypes.SdlFile()
                     .setName(fileName)
-                    .setFilePath('./test_icon_1.png')
+                    .setFilePath(this._filePath)
                     .setType(SDL.rpc.enums.FileType.GRAPHIC_PNG)
                     .setPersistent(true);
 
@@ -118,7 +119,7 @@
                 screenManager.setTitle('JavaScript Library');
                 screenManager.setTextAlignment(SDL.rpc.enums.TextAlignment.RIGHT_ALIGNED);
                 screenManager.setPrimaryGraphic(new SDL.manager.file.filetypes.SdlArtwork('sdl-logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)
-                    .setFilePath('./test_icon_1.png'));
+                    .setFilePath(this._filePath));
             }
 
             async _onHmiStatusListener (onHmiStatus) {
@@ -128,7 +129,7 @@
                 // wait for the FULL state for more functionality
                 if (hmiLevel === SDL.rpc.enums.HMILevel.HMI_FULL) {
                     const art1 = new SDL.manager.file.filetypes.SdlArtwork('logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)
-                        .setFilePath('./test_icon_1.png');
+                        .setFilePath(this._filePath);
 
                     let state1 = new SDL.manager.screen.utils.SoftButtonState('ROCK', 'rock', art1);
                     let state2 = new SDL.manager.screen.utils.SoftButtonState('PAPER', 'paper', art1);

--- a/examples/js/hello-sdl/index.html
+++ b/examples/js/hello-sdl/index.html
@@ -36,11 +36,11 @@
     <script src='./SDL.min.js'></script>
 
     <script>
-        const filePath = './test_icon_1.png';
         class HelloSdl {
             constructor () {
                 const appId = 'hello-js';
                 const fileName = `${appId}_icon`;
+                this._filePath = './test_icon_1.png';
                 const file = new SDL.manager.file.filetypes.SdlFile()
                     .setName(fileName)
                     .setFilePath(this._filePath)

--- a/examples/node/hello-sdl-tcp/index.js
+++ b/examples/node/hello-sdl-tcp/index.js
@@ -30,16 +30,16 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-const fs = require('fs');
 const SDL = require('../../../lib/node/dist/SDL.min.js');
 const CONFIG = require('./config.js');
+const filePath = './test_icon_1.png';
 
 class AppClient {
     constructor () {
-        const fileName = `${CONFIG.appId}_icon.gif`;
+        const fileName = `${CONFIG.appId}_icon`;
         const file = new SDL.manager.file.filetypes.SdlFile()
             .setName(fileName)
-            .setFilePath('./test_icon_1.png')
+            .setFilePath(filePath)
             .setType(SDL.rpc.enums.FileType.GRAPHIC_PNG)
             .setPersistent(true);
 
@@ -115,7 +115,7 @@ class AppClient {
         screenManager.setTitle('JavaScript Library');
         screenManager.setTextAlignment(SDL.rpc.enums.TextAlignment.RIGHT_ALIGNED);
         screenManager.setPrimaryGraphic(new SDL.manager.file.filetypes.SdlArtwork('sdl-logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)
-            .setFilePath('./test_icon_1.png'));
+            .setFilePath(filePath));
     }
 
     async _onHmiStatusListener (onHmiStatus) {
@@ -125,7 +125,7 @@ class AppClient {
         // wait for the FULL state for more functionality
         if (hmiLevel === SDL.rpc.enums.HMILevel.HMI_FULL) {
             const art1 = new SDL.manager.file.filetypes.SdlArtwork('logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)
-                .setFilePath('./test_icon_1.png');
+                .setFilePath(filePath);
 
             const state1 = new SDL.manager.screen.utils.SoftButtonState('ROCK', 'rock', art1);
             const state2 = new SDL.manager.screen.utils.SoftButtonState('PAPER', 'paper', art1);

--- a/examples/node/hello-sdl-tcp/index.js
+++ b/examples/node/hello-sdl-tcp/index.js
@@ -32,14 +32,14 @@
 
 const SDL = require('../../../lib/node/dist/SDL.min.js');
 const CONFIG = require('./config.js');
-const filePath = './test_icon_1.png';
 
 class AppClient {
     constructor () {
         const fileName = `${CONFIG.appId}_icon`;
+        this._filePath = './test_icon_1.png';
         const file = new SDL.manager.file.filetypes.SdlFile()
             .setName(fileName)
-            .setFilePath(filePath)
+            .setFilePath(this._filePath)
             .setType(SDL.rpc.enums.FileType.GRAPHIC_PNG)
             .setPersistent(true);
 
@@ -115,7 +115,7 @@ class AppClient {
         screenManager.setTitle('JavaScript Library');
         screenManager.setTextAlignment(SDL.rpc.enums.TextAlignment.RIGHT_ALIGNED);
         screenManager.setPrimaryGraphic(new SDL.manager.file.filetypes.SdlArtwork('sdl-logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)
-            .setFilePath(filePath));
+            .setFilePath(this._filePath));
     }
 
     async _onHmiStatusListener (onHmiStatus) {
@@ -125,7 +125,7 @@ class AppClient {
         // wait for the FULL state for more functionality
         if (hmiLevel === SDL.rpc.enums.HMILevel.HMI_FULL) {
             const art1 = new SDL.manager.file.filetypes.SdlArtwork('logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)
-                .setFilePath(filePath);
+                .setFilePath(this._filePath);
 
             const state1 = new SDL.manager.screen.utils.SoftButtonState('ROCK', 'rock', art1);
             const state2 = new SDL.manager.screen.utils.SoftButtonState('PAPER', 'paper', art1);

--- a/examples/node/hello-sdl/AppClient.js
+++ b/examples/node/hello-sdl/AppClient.js
@@ -32,14 +32,14 @@
 
 const SDL = require('../../../lib/node/dist/SDL.min.js');
 const CONFIG = require('./config.js');
-const filePath = './test_icon_1.png';
 
 class AppClient {
     constructor (wsClient) {
         const fileName = `${CONFIG.appId}_icon`;
+        this._filePath = './test_icon_1.png';
         const file = new SDL.manager.file.filetypes.SdlFile()
             .setName(fileName)
-            .setFilePath(filePath)
+            .setFilePath(this._filePath)
             .setType(SDL.rpc.enums.FileType.GRAPHIC_PNG)
             .setPersistent(true);
 
@@ -141,10 +141,10 @@ class AppClient {
             screenManager.setTitle('JavaScript Library');
             screenManager.setTextAlignment(SDL.rpc.enums.TextAlignment.RIGHT_ALIGNED);
             screenManager.setPrimaryGraphic(new SDL.manager.file.filetypes.SdlArtwork('sdl-logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)
-                .setFilePath(filePath));
+                .setFilePath(this._filePath));
 
             const art1 = new SDL.manager.file.filetypes.SdlArtwork('logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)
-                .setFilePath(filePath);
+                .setFilePath(this._filePath);
 
             const state1 = new SDL.manager.screen.utils.SoftButtonState('ROCK', 'rock', art1);
             const state2 = new SDL.manager.screen.utils.SoftButtonState('PAPER', 'paper', art1);

--- a/examples/node/hello-sdl/AppClient.js
+++ b/examples/node/hello-sdl/AppClient.js
@@ -30,16 +30,16 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-const fs = require('fs');
 const SDL = require('../../../lib/node/dist/SDL.min.js');
 const CONFIG = require('./config.js');
+const filePath = './test_icon_1.png';
 
 class AppClient {
     constructor (wsClient) {
-        const fileName = `${CONFIG.appId}_icon.gif`;
+        const fileName = `${CONFIG.appId}_icon`;
         const file = new SDL.manager.file.filetypes.SdlFile()
             .setName(fileName)
-            .setFilePath('./test_icon_1.png')
+            .setFilePath(filePath)
             .setType(SDL.rpc.enums.FileType.GRAPHIC_PNG)
             .setPersistent(true);
 
@@ -141,10 +141,10 @@ class AppClient {
             screenManager.setTitle('JavaScript Library');
             screenManager.setTextAlignment(SDL.rpc.enums.TextAlignment.RIGHT_ALIGNED);
             screenManager.setPrimaryGraphic(new SDL.manager.file.filetypes.SdlArtwork('sdl-logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)
-                .setFilePath('./test_icon_1.png'));
+                .setFilePath(filePath));
 
             const art1 = new SDL.manager.file.filetypes.SdlArtwork('logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)
-                .setFilePath('./test_icon_1.png');
+                .setFilePath(filePath);
 
             const state1 = new SDL.manager.screen.utils.SoftButtonState('ROCK', 'rock', art1);
             const state2 = new SDL.manager.screen.utils.SoftButtonState('PAPER', 'paper', art1);

--- a/examples/webengine/hello-sdl/index.html
+++ b/examples/webengine/hello-sdl/index.html
@@ -40,7 +40,7 @@
 
         class HelloSdl {
             constructor () {
-                const fileName = `${sdl_manifest.appId}_icon.gif`;
+                const fileName = `${sdl_manifest.appId}_icon`;
                 const file = new SDL.manager.file.filetypes.SdlFile()
                     .setName(fileName)
                     .setFilePath(sdl_manifest.appIcon)


### PR DESCRIPTION
Fixes #158 

This PR is **ready** for review.

### Testing Plan
Run each of the test apps and ensure that they work as expected and display properly.

### Summary
There is now only one copy of the test image in the root directory.
The 'fs' module is no longer imported in the example apps.
The fileName is no longer postfixed with .gif