### PR TITLE
Remove unused private property and add a missing one in the constructor

### DIFF
--- a/lib/js/src/manager/lifecycle/LifecycleManager.js
+++ b/lib/js/src/manager/lifecycle/LifecycleManager.js
@@ -89,6 +89,7 @@ class LifecycleManager {
         this._rpcListeners = new Map(); // <Number, Array<function(RpcResponse)>>
         this._systemCapabilityManager = new SystemCapabilityManager(this);
         this._encryptionLifecycleManager = null;
+        this._registerAppInterfaceResponse = null;
     }
 
     /**

--- a/lib/js/src/rpc/RpcRequest.js
+++ b/lib/js/src/rpc/RpcRequest.js
@@ -43,7 +43,6 @@ class RpcRequest extends RpcMessage {
     constructor (store) {
         super(store);
         this.setRPCType(RpcType.REQUEST);
-        this._promise = null;
     }
 }
 


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
_registerAppInterfaceResponse needs to be defined in the constructor of the LCM, and the _promise property of RpcRequest wasn't removed with the methods before