### PR TITLE
Log the library version using the package.json version property

### DIFF
--- a/lib/js/generate.js
+++ b/lib/js/generate.js
@@ -4,6 +4,10 @@ const fs = require('fs');
 const baseDir = __dirname;
 const paths = [];
 
+// inject logging the version into the library when bundling
+const package = require('../../package.json');
+const packageMessageString = `SDL Javascript library version ${package.version}`;
+
 function parseDir (dir, tree) {
     const currentLocation = `${baseDir + dir}/`;
     const files = fs.readdirSync(currentLocation);
@@ -85,6 +89,8 @@ stringifiedTree = stringifiedTree.replace(/\w\n/g, match => `${match[0]},\n`);
 output += `
 
 const SDL = ${stringifiedTree};
+
+console.log('${packageMessageString}');
 
 export default SDL;`;
 

--- a/lib/js/generate.js
+++ b/lib/js/generate.js
@@ -6,7 +6,7 @@ const paths = [];
 
 // inject logging the version into the library when bundling
 const package = require('../../package.json');
-const packageMessageString = `SDL Javascript library version ${package.version}`;
+const packageMessageString = `SDL JavaScript library version ${package.version}`;
 
 function parseDir (dir, tree) {
     const currentLocation = `${baseDir + dir}/`;

--- a/lib/node/generate.js
+++ b/lib/node/generate.js
@@ -6,6 +6,10 @@ const baseDir = __dirname;
 const paths = [];
 const pathsObj = {};
 
+// inject logging the version into the library when bundling
+const package = require('../../package.json');
+const packageMessageString = `SDL Javascript library version ${package.version}`;
+
 function parseDir (dir, tree, value) {
     const currentLocation = `${baseDir + dir}/`;
     const files = fs.readdirSync(currentLocation);
@@ -103,6 +107,8 @@ stringifiedTree = stringifiedTree.replace(/\w\n/g, match => `${match[0]},\n`);
 output += `
 
 const SDL = ${stringifiedTree};
+
+console.log('${packageMessageString}');
 
 export default SDL;`;
 

--- a/lib/node/generate.js
+++ b/lib/node/generate.js
@@ -8,7 +8,7 @@ const pathsObj = {};
 
 // inject logging the version into the library when bundling
 const package = require('../../package.json');
-const packageMessageString = `SDL Javascript library version ${package.version}`;
+const packageMessageString = `SDL JavaScript library version ${package.version}`;
 
 function parseDir (dir, tree, value) {
     const currentLocation = `${baseDir + dir}/`;


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
Use the package.json to log the library version in the main builds