### PR TITLE
validateType is private

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -44,7 +44,7 @@ The following special rules shall apply to the RPC generation script for the Jav
 * RPC enums shall extend the `Enum` class and be stored in `/lib/js/src/rpc/enums`
 * Uses of the "sync" prefix shall be replaced with "sdl" (where it would not break functionality). E.g. `SyncMsgVersion -> SdlMsgVersion`. This applies to member variables and their accessors. The key used when creating the RPC message JSON should match that of the RPC Spec.
 * The `_MAP` keys and static getters of the `FunctionID` enum shall not include the `ID` suffix. e.g. `RegisterAppInterfaceID -> RegisterAppInterface`. All references to the `FunctionID` enum shall adopt this as well to ensure valid references.
-* `set` methods of RPC messages and RPC structs shall validate the type of the passed parameter by immediately calling `this.validateType([targetClass], [parameter]);`, followed by storing the passed parameter or object. Target classes used for validation must be imported into each respective message/struct file immediately following any copyright notice block comments.
+* `set` methods of RPC messages and RPC structs shall validate the type of the passed parameter by immediately calling `this._validateType([targetClass], [parameter]);`, followed by storing the passed parameter or object. Target classes used for validation must be imported into each respective message/struct file immediately following any copyright notice block comments.
 * Each extended RPC enumeration class must be named to match the enum name in the RPC Spec
 
 

--- a/generator/README.md
+++ b/generator/README.md
@@ -718,7 +718,7 @@ For each `<param>` the getter and setter methods should be defined in the class:
     * The setter should return `this` instance to support the chaining.
 4. If the `<param>` has the `"type"` attribute value as the one of `<enum>` or `<struct>` name:
     * The getter should call and return the result of the `this.getObject` method, where the first parameter is the corresponding Struct or Enum class, the second is the value of the corresponding static property described above;
-    * The setter should validate the received value by calling the `this.validateType` method, where the fist parameter is the Struct or Enum class corresponding to the `"type"` attribute value of `<param>`, the second is the value itself;
+    * The setter should validate the received value by calling the `this._validateType` method, where the fist parameter is the Struct or Enum class corresponding to the `"type"` attribute value of `<param>`, the second is the value itself;
     * The setter should call the `this.setParameter` method, where the first parameter is the value of the corresponding static property described above, the second is the value passed into setter;
     * The setter should return `this` instance to support the chaining.
 
@@ -747,7 +747,7 @@ Examples:
  * @return {VehicleDataResult}
  */
 setDataType(type) {
-    this.validateType(VehicleDataType, type);
+    this._validateType(VehicleDataType, type);
     this.setParameter(VehicleDataResult.KEY_DATA_TYPE, type);
     return this;
 }
@@ -855,7 +855,7 @@ class VehicleDataResult extends RpcStruct {
      * @return {VehicleDataResult}
      */
     setDataType (type) {
-        this.validateType(VehicleDataType, type);
+        this._validateType(VehicleDataType, type);
         this.setParameter(VehicleDataResult.KEY_DATA_TYPE, type);
         return this;
     }
@@ -872,7 +872,7 @@ class VehicleDataResult extends RpcStruct {
      * @return {VehicleDataResult}
      */
     setResultCode (code) {
-        this.validateType(VehicleDataResultCode, code);
+        this._validateType(VehicleDataResultCode, code);
         this.setParameter(VehicleDataResult.KEY_RESULT_CODE, code);
         return this;
     }
@@ -1026,7 +1026,7 @@ For each `<param>` the getter and setter methods should be defined in the class:
     * The setter should return `this` instance to support the chaining.
 3. If the `<param>` has the `"type"` attribute value as the one of `<enum>` or `<struct>` name:
     * The getter should call and return the result of the `this.getObject` method, where the first parameter is the corresponding Struct or Enum class, the second is the value of the corresponding static property described above;
-    * The setter should validate the received value by calling the `this.validateType` method, where the fist parameter is the Struct or Enum class corresponding to the `"type"` attribute value of `<param>`, the second is the value itself;
+    * The setter should validate the received value by calling the `this._validateType` method, where the fist parameter is the Struct or Enum class corresponding to the `"type"` attribute value of `<param>`, the second is the value itself;
     * The setter should call the `this.setParameter` method, where the first parameter is the value of the corresponding static property described above, the second is the value passed into setter;
     * The setter should return `this` instance to support the chaining.
 4. The exclusion are `<param>` with name `success`, `resultCode` and `info` of `<function>` with the attribute `messagetype="response"`, in this case they should be omitted.
@@ -1071,7 +1071,7 @@ getCmdID() {
  * @return {AddCommand}
  */
 setMenuParams(menuParams) {
-    this.validateType(MenuParams, menuParams);
+    this._validateType(MenuParams, menuParams);
     this.setParameter(AddCommand.KEY_MENU_PARAMS, menuParams);
     return this;
 }
@@ -1088,7 +1088,7 @@ getMenuParams() {
  * @return {OnLanguageChange}
  */
 setHmiDisplayLanguage(language) {
-    this.validateType(Language, language);
+    this._validateType(Language, language);
     this.setParameter(OnLanguageChange.KEY_HMI_DISPLAY_LANGUAGE, language);
     return this;
 }
@@ -1216,7 +1216,7 @@ class AddCommand extends RpcRequest {
      * @return {AddCommand}
      */
     setMenuParams (params) {
-        this.validateType(MenuParams, params);
+        this._validateType(MenuParams, params);
         this.setParameter(AddCommand.KEY_MENU_PARAMS, params);
         return this;
     }
@@ -1251,7 +1251,7 @@ class AddCommand extends RpcRequest {
      * @return {AddCommand}
      */
     setCmdIcon (icon) {
-        this.validateType(Image, icon);
+        this._validateType(Image, icon);
         this.setParameter(AddCommand.KEY_CMD_ICON, icon);
         return this;
     }
@@ -1414,7 +1414,7 @@ class PerformInteractionResponse extends RpcResponse {
      * @return {PerformInteractionResponse}
      */
     setTriggerSource (source) {
-        this.validateType(TriggerSource, source);
+        this._validateType(TriggerSource, source);
         this.setParameter(PerformInteractionResponse.KEY_TRIGGER_SOURCE, source);
         return this;
     }
@@ -1497,7 +1497,7 @@ class OnLanguageChange extends RpcNotification {
      * @return {OnLanguageChange}
      */
     setLanguage (language) {
-        this.validateType(Language, language);
+        this._validateType(Language, language);
         this.setParameter(OnLanguageChange.KEY_LANGUAGE, language);
         return this;
     }
@@ -1514,7 +1514,7 @@ class OnLanguageChange extends RpcNotification {
      * @return {OnLanguageChange}
      */
     setHmiDisplayLanguage (language) {
-        this.validateType(Language, language);
+        this._validateType(Language, language);
         this.setParameter(OnLanguageChange.KEY_HMI_DISPLAY_LANGUAGE, language);
         return this;
     }

--- a/generator/templates/base_struct_function.js
+++ b/generator/templates/base_struct_function.js
@@ -51,7 +51,7 @@
      */
     set{{method.method_title}} ({{method.param_name}}) {
         {%- if method.external %}
-        this.validateType({{method.external}}, {{method.param_name}}{{ ', true' if '[]' in method.type }});
+        this._validateType({{method.external}}, {{method.param_name}}{{ ', true' if '[]' in method.type }});
         {%- endif %}
         this.setParameter({{name}}.{{method.key}}, {{method.param_name}});
         return this;

--- a/generator/templates/scripts/RegisterAppInterfaceRequest.js
+++ b/generator/templates/scripts/RegisterAppInterfaceRequest.js
@@ -4,7 +4,7 @@
  * @returns {RegisterAppInterface} - The class instance to support method chaining.
  */
 setFullAppId (fullAppId) {
-    this.validateType(String, fullAppId);
+    this._validateType(String, fullAppId);
 
     if (fullAppId !== null) {
         fullAppId = fullAppId.toLowerCase();
@@ -37,7 +37,7 @@ getFullAppId () {
  * @returns {RegisterAppInterface} - The class instance to support method chaining.
  */
 _setAppId (appId) {
-    this.validateType(String, appId);
+    this._validateType(String, appId);
 
     this.setParameter(RegisterAppInterface.KEY_APP_ID, appId);
     return this;

--- a/lib/js/src/rpc/RpcStruct.js
+++ b/lib/js/src/rpc/RpcStruct.js
@@ -124,17 +124,18 @@ class RpcStruct {
 
     /**
      * Throw an error if the given variable is not of the desired type.
+     * @private
      * @param {Function} tClass - The desired data type.
      * @param {Object} obj - The variable to check the type of.
      * @param {Boolean} isArray - Whether or not the given variable is an array to be iterated through.
      */
-    validateType (tClass, obj, isArray = false) {
+    _validateType (tClass, obj, isArray = false) {
         if (isArray) {
             if (!Array.isArray(obj)) {
                 throw new Error(`${obj.name} must be an array containing items of type ${tClass.name}`);
             } else {
                 for (const item of obj) {
-                    this.validateType(tClass, item, false);
+                    this._validateType(tClass, item, false);
                 }
             }
         } else if (


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
Makes RpcStruct's validateType a private method. Note that running the generator will change all the existing validateType usages to the correct method name