### PR TITLE
Remove setIsMediaApp and instead check hmitypes when setting

### DIFF
--- a/examples/js/hello-sdl/index.html
+++ b/examples/js/hello-sdl/index.html
@@ -50,7 +50,6 @@
                 this._appConfig = new SDL.manager.AppConfig()
                     .setAppId(appId)
                     .setAppName('Hello JS')
-                    .setIsMediaApp(false)
                     .setLanguageDesired(SDL.rpc.enums.Language.EN_US)
                     .setHmiDisplayLanguageDesired(SDL.rpc.enums.Language.EN_US)
                     .setAppTypes([

--- a/examples/node/hello-sdl-tcp/index.js
+++ b/examples/node/hello-sdl-tcp/index.js
@@ -46,7 +46,6 @@ class AppClient {
         this._appConfig = new SDL.manager.AppConfig()
             .setAppId(CONFIG.appId)
             .setAppName(CONFIG.appName)
-            .setIsMediaApp(false)
             .setLanguageDesired(SDL.rpc.enums.Language.EN_US)
             .setHmiDisplayLanguageDesired(SDL.rpc.enums.Language.EN_US)
             .setAppTypes([

--- a/examples/node/hello-sdl/AppClient.js
+++ b/examples/node/hello-sdl/AppClient.js
@@ -46,7 +46,6 @@ class AppClient {
         this._appConfig = new SDL.manager.AppConfig()
             .setAppId(CONFIG.appId)
             .setAppName(CONFIG.appName)
-            .setIsMediaApp(false)
             .setLanguageDesired(SDL.rpc.enums.Language.EN_US)
             .setHmiDisplayLanguageDesired(SDL.rpc.enums.Language.EN_US)
             .setAppTypes([

--- a/examples/webengine/hello-sdl/index.html
+++ b/examples/webengine/hello-sdl/index.html
@@ -49,7 +49,6 @@
 
                 this._appConfig = new SDL.manager.AppConfig()
                     .loadManifest(sdl_manifest)
-                    .setIsMediaApp(false)
                     .setLanguageDesired(SDL.rpc.enums.Language.EN_US)
                     .setHmiDisplayLanguageDesired(SDL.rpc.enums.Language.EN_US)
                     .setTransportConfig(new SDL.transport.WebSocketClientConfig());

--- a/lib/js/src/manager/AppConfig.js
+++ b/lib/js/src/manager/AppConfig.js
@@ -31,7 +31,7 @@
 */
 
 import { Language } from '../rpc/enums/Language.js';
-import { AppHMIType } from '../rpc/enums/AppHMIType.js';
+import { AppHMIType, AppHMIType } from '../rpc/enums/AppHMIType.js';
 import { Version } from '../util/Version.js';
 
 class AppConfig {
@@ -225,10 +225,8 @@ class AppConfig {
      * @returns {AppConfig} - A reference to this instance to support method chaining.
      */
     setAppTypes (appTypes) {
-        if (appTypes.includes(AppHMIType.MEDIA)) {
-            this._isMediaApp = true;
-        }
         this._appTypes = appTypes;
+        this._isMediaApp = appTypes.includes(AppHMIType.MEDIA);
         return this;
     }
 

--- a/lib/js/src/manager/AppConfig.js
+++ b/lib/js/src/manager/AppConfig.js
@@ -184,24 +184,6 @@ class AppConfig {
     }
 
     /**
-     * Set whether or not the app is a Media app.
-     * @param {Boolean} isMediaApp - Whether or not the app is a Media app.
-     * @returns {AppConfig} - A reference to this instance to support method chaining.
-     */
-    setIsMediaApp (isMediaApp) {
-        this._isMediaApp = isMediaApp;
-        return this;
-    }
-
-    /**
-     * Get whether or not the app is a Media app.
-     * @returns {Boolean} - Whether or not the app is a media app.
-     */
-    isMediaApp () {
-        return this._isMediaApp;
-    }
-
-    /**
      * Set the desired language of the application.
      * @param {Language} languageDesired - A Language enum value.
      * @returns {AppConfig} - A reference to this instance to support method chaining.
@@ -243,6 +225,9 @@ class AppConfig {
      * @returns {AppConfig} - A reference to this instance to support method chaining.
      */
     setAppTypes (appTypes) {
+        if (appTypes.includes(AppHMIType.MEDIA)) {
+            this._isMediaApp = true;
+        }
         this._appTypes = appTypes;
         return this;
     }

--- a/lib/js/src/manager/AppConfig.js
+++ b/lib/js/src/manager/AppConfig.js
@@ -226,7 +226,9 @@ class AppConfig {
      */
     setAppTypes (appTypes) {
         this._appTypes = appTypes;
-        this._isMediaApp = appTypes.includes(AppHMIType.MEDIA);
+        if (appTypes !== null && appTypes !== undefined) {
+            this._isMediaApp = appTypes.includes(AppHMIType.MEDIA);
+        }
         return this;
     }
 

--- a/lib/js/src/manager/AppConfig.js
+++ b/lib/js/src/manager/AppConfig.js
@@ -31,7 +31,7 @@
 */
 
 import { Language } from '../rpc/enums/Language.js';
-import { AppHMIType, AppHMIType } from '../rpc/enums/AppHMIType.js';
+import { AppHMIType } from '../rpc/enums/AppHMIType.js';
 import { Version } from '../util/Version.js';
 
 class AppConfig {

--- a/lib/js/src/manager/lifecycle/_LifecycleManager.js
+++ b/lib/js/src/manager/lifecycle/_LifecycleManager.js
@@ -42,7 +42,6 @@ import { ArrayTools } from '../../util/ArrayTools.js';
 import { SdlMsgVersion } from '../../rpc/structs/SdlMsgVersion.js';
 import { FunctionID } from '../../rpc/enums/FunctionID.js';
 import { _ServiceType } from '../../protocol/enums/_ServiceType.js';
-import { AppHMIType } from '../../rpc/enums/AppHMIType.js';
 
 /**
  * NOTE: This could all change and should only be used for testing.

--- a/lib/js/src/manager/lifecycle/_LifecycleManager.js
+++ b/lib/js/src/manager/lifecycle/_LifecycleManager.js
@@ -355,7 +355,7 @@ class _LifecycleManager {
             .setAppHMIType(this._appConfig.getAppTypes())
             .setLanguageDesired(this._appConfig.getLanguageDesired())
             .setHmiDisplayLanguageDesired(this._appConfig.getHmiDisplayLanguageDesired())
-            .setIsMediaApplication(this._appConfig.getAppTypes().includes(AppHMIType.MEDIA))
+            .setIsMediaApplication(this._appConfig._isMediaApp)
             .setDayColorScheme(this._appConfig.getDayColorScheme())
             .setNightColorScheme(this._appConfig.getNightColorScheme())
             .setCorrelationId(_LifecycleManager.REGISTER_APP_INTERFACE_CORRELATION_ID);

--- a/lib/js/src/manager/lifecycle/_LifecycleManager.js
+++ b/lib/js/src/manager/lifecycle/_LifecycleManager.js
@@ -42,6 +42,7 @@ import { ArrayTools } from '../../util/ArrayTools.js';
 import { SdlMsgVersion } from '../../rpc/structs/SdlMsgVersion.js';
 import { FunctionID } from '../../rpc/enums/FunctionID.js';
 import { _ServiceType } from '../../protocol/enums/_ServiceType.js';
+import { AppHMIType } from '../../rpc/enums/AppHMIType.js';
 
 /**
  * NOTE: This could all change and should only be used for testing.
@@ -354,7 +355,7 @@ class _LifecycleManager {
             .setAppHMIType(this._appConfig.getAppTypes())
             .setLanguageDesired(this._appConfig.getLanguageDesired())
             .setHmiDisplayLanguageDesired(this._appConfig.getHmiDisplayLanguageDesired())
-            .setIsMediaApplication(this._appConfig.isMediaApp())
+            .setIsMediaApplication(this._appConfig.getAppTypes().includes(AppHMIType.MEDIA))
             .setDayColorScheme(this._appConfig.getDayColorScheme())
             .setNightColorScheme(this._appConfig.getNightColorScheme())
             .setCorrelationId(_LifecycleManager.REGISTER_APP_INTERFACE_CORRELATION_ID);


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
Removed the setIsMediaApp and isMediaApp methods from the AppConfig in favor of setting the _isMediaApp property based on the set AppHMITypes.