### PR TITLE
Remove HmiLanguageDesired property and use the already existing LanguageDesired property

### DIFF
--- a/examples/node/hello-sdl-tcp/index.js
+++ b/examples/node/hello-sdl-tcp/index.js
@@ -47,7 +47,6 @@ class AppClient {
             .setAppId(CONFIG.appId)
             .setAppName(CONFIG.appName)
             .setLanguageDesired(SDL.rpc.enums.Language.EN_US)
-            .setHmiDisplayLanguageDesired(SDL.rpc.enums.Language.EN_US)
             .setAppTypes([
                 SDL.rpc.enums.AppHMIType.DEFAULT,
             ])

--- a/examples/node/hello-sdl/AppClient.js
+++ b/examples/node/hello-sdl/AppClient.js
@@ -47,7 +47,6 @@ class AppClient {
             .setAppId(CONFIG.appId)
             .setAppName(CONFIG.appName)
             .setLanguageDesired(SDL.rpc.enums.Language.EN_US)
-            .setHmiDisplayLanguageDesired(SDL.rpc.enums.Language.EN_US)
             .setAppTypes([
                 SDL.rpc.enums.AppHMIType.DEFAULT,
             ])

--- a/examples/webengine/hello-sdl/index.html
+++ b/examples/webengine/hello-sdl/index.html
@@ -50,7 +50,6 @@
                 this._appConfig = new SDL.manager.AppConfig()
                     .loadManifest(sdl_manifest)
                     .setLanguageDesired(SDL.rpc.enums.Language.EN_US)
-                    .setHmiDisplayLanguageDesired(SDL.rpc.enums.Language.EN_US)
                     .setTransportConfig(new SDL.transport.WebSocketClientConfig());
 
                 const managerListener = new SDL.manager.SdlManagerListener();

--- a/lib/js/src/manager/AppConfig.js
+++ b/lib/js/src/manager/AppConfig.js
@@ -49,7 +49,6 @@ class AppConfig {
         this._vrSynonyms = null;
         this._isMediaApp = false;
         this._languageDesired = Language.EN_US;
-        this._hmiDisplayLanguageDesired = Language.EN_US;
         this._appTypes = [AppHMIType.DEFAULT]; // hmiTypes
         this._dayColorScheme = null;
         this._nightColorScheme = null;
@@ -199,24 +198,6 @@ class AppConfig {
      */
     getLanguageDesired () {
         return this._languageDesired;
-    }
-
-    /**
-     * Set the desired HMI Display Language.
-     * @param {Language} hmiDisplayLanguageDesired - A Language enum value.
-     * @returns {AppConfig} - A reference to this instance to support method chaining.
-     */
-    setHmiDisplayLanguageDesired (hmiDisplayLanguageDesired) {
-        this._hmiDisplayLanguageDesired = hmiDisplayLanguageDesired;
-        return this;
-    }
-
-    /**
-     * Get the desired HMI Display Language.
-     * @returns {Language} - A Langauge enum value.
-     */
-    getHmiDisplayLanguageDesired () {
-        return this._hmiDisplayLanguageDesired;
     }
 
     /**

--- a/lib/js/src/manager/SdlManager.js
+++ b/lib/js/src/manager/SdlManager.js
@@ -222,7 +222,7 @@ class SdlManager extends _SdlManagerBase {
     _checkLifecycleConfiguration () {
         const actualLanguage = this._lifecycleManager.getRegisterAppInterfaceResponse().getLanguage();
 
-        if (actualLanguage !== null && actualLanguage !== this._appConfig.getHmiDisplayLanguageDesired()) {
+        if (actualLanguage !== null && actualLanguage !== this._appConfig.getLanguageDesired()) {
             // HMI language doesn't match the app's desired display language
             const lifecycleConfigUpdate = this._managerListener.managerShouldUpdateLifecycle(actualLanguage);
 

--- a/lib/js/src/manager/lifecycle/_LifecycleManager.js
+++ b/lib/js/src/manager/lifecycle/_LifecycleManager.js
@@ -353,7 +353,7 @@ class _LifecycleManager {
             .setNgnMediaScreenAppName(this._appConfig.getShortAppName())
             .setAppHMIType(this._appConfig.getAppTypes())
             .setLanguageDesired(this._appConfig.getLanguageDesired())
-            .setHmiDisplayLanguageDesired(this._appConfig.getHmiDisplayLanguageDesired())
+            .setHmiDisplayLanguageDesired(this._appConfig.getLanguageDesired())
             .setIsMediaApplication(this._appConfig._isMediaApp)
             .setDayColorScheme(this._appConfig.getDayColorScheme())
             .setNightColorScheme(this._appConfig.getNightColorScheme())


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
Removes HmiLanguageDesired property in favor of the already existing LanguageDesired property since having both is unnecessary.