### PR TITLE
Add deprecated flags to Enums when applicable

### DIFF
--- a/generator/templates/base_struct_function.js
+++ b/generator/templates/base_struct_function.js
@@ -39,10 +39,16 @@
      {% endif -%}
      {% if not method.description -%}
      * @param {{'%s%s%s %s'|format('{', method.type, '}', method.param_name)}} - The desired {{method.method_title}}.
+     {% if method.param_values is defined and method.param_values -%}
+     {{method.param_values}}
+     {% endif -%}
      {% else -%}
      * {% for d in method.description -%}
      {% if loop.index == 1 -%}
      @param {{'%s%s%s %s - %s'|format('{', method.type, '}', method.param_name, d)}} - The desired {{method.method_title}}.
+     {% if method.param_values is defined and method.param_values -%}
+     * {{method.param_values}}
+     {% endif -%}
      {% else -%}
      * {{d}}
      {% endif -%} {% endfor -%}

--- a/generator/templates/base_struct_function.js
+++ b/generator/templates/base_struct_function.js
@@ -39,19 +39,16 @@
      {% endif -%}
      {% if not method.description -%}
      * @param {{'%s%s%s %s'|format('{', method.type, '}', method.param_name)}} - The desired {{method.method_title}}.
-     {% if method.param_values is defined and method.param_values -%}
-     {{method.param_values}}
-     {% endif -%}
      {% else -%}
      * {% for d in method.description -%}
      {% if loop.index == 1 -%}
      @param {{'%s%s%s %s - %s'|format('{', method.type, '}', method.param_name, d)}} - The desired {{method.method_title}}.
-     {% if method.param_values is defined and method.param_values -%}
-     * {{method.param_values}}
-     {% endif -%}
      {% else -%}
      * {{d}}
      {% endif -%} {% endfor -%}
+     {% endif -%}
+     {% if method.param_values is defined and method.param_values -%}
+     * {{method.param_values}}
      {% endif -%}
      * @returns {{'%s%s%s'|format('{', name, '}')}} - The class instance for method chaining.
      */

--- a/generator/templates/enum_template.js
+++ b/generator/templates/enum_template.js
@@ -28,7 +28,7 @@
 
     /**
      * Get the enum value for {{method.method_title}}.
-     {%- if deprecated is defined %}
+     {%- if method.deprecated is defined and method.deprecated %}
      * @deprecated
      {%- endif %}
      {%- for d in method.description %}

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -186,7 +186,6 @@ class InterfaceProducerCommon(ABC):
         :param item_type: type of parent element from initial Model
         :return: tuple with 3 element, which going to be applied to jinja2 template
         """
-        print(param.deprecated)
         name, description = self.extract_name_description(param)
         type_name = self.extract_type(param)
         imports = self.extract_imports(param, item_type)

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -10,7 +10,9 @@ from collections import namedtuple, OrderedDict
 from pathlib import Path
 
 from model.array import Array
+from model.boolean import Boolean
 from model.enum import Enum
+from model.enum_element import EnumElement
 from model.float import Float
 from model.function import Function
 from model.integer import Integer
@@ -74,9 +76,15 @@ class InterfaceProducerCommon(ABC):
         if hasattr(param.param_type, 'min_size'):
             p['array_min_size'] = param.param_type.min_size   
         if hasattr(param, 'default_value'):
-            p['default_value'] = param.default_value
+            if hasattr(param.default_value, 'name'):
+                p['default_value'] = param.default_value.name
+            else:
+                p['default_value'] = param.default_value
         elif hasattr(param.param_type, 'default_value'):
-            p['default_value'] = param.param_type.default_value
+            if hasattr(param.param_type.default_value, 'name'):
+                p['default_value'] = param.param_type.default_value.name
+            else:  
+                p['default_value'] = param.param_type.default_value
         if hasattr(param.param_type, 'max_value'):
             p['num_max_value'] = param.param_type.max_value
         elif hasattr(param.param_type, 'element_type') and hasattr(param.param_type.element_type, 'max_value'):

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -10,9 +10,7 @@ from collections import namedtuple, OrderedDict
 from pathlib import Path
 
 from model.array import Array
-from model.boolean import Boolean
 from model.enum import Enum
-from model.enum_element import EnumElement
 from model.float import Float
 from model.function import Function
 from model.integer import Integer
@@ -188,6 +186,7 @@ class InterfaceProducerCommon(ABC):
         :param item_type: type of parent element from initial Model
         :return: tuple with 3 element, which going to be applied to jinja2 template
         """
+        print(param.deprecated)
         name, description = self.extract_name_description(param)
         type_name = self.extract_type(param)
         imports = self.extract_imports(param, item_type)

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -32,7 +32,7 @@ class InterfaceProducerCommon(ABC):
         self.mapping = mapping
         self.key_words = key_words
         self.imports = namedtuple('Imports', 'what wherefrom')
-        self.methods = namedtuple('Methods', 'key method_title external description param_name param_values type')
+        self.methods = namedtuple('Methods', 'key method_title external description param_name param_values type deprecated history')
         self.params = namedtuple('Params', 'key value')
 
     @property
@@ -203,8 +203,12 @@ class InterfaceProducerCommon(ABC):
         title = self.replace_keywords(param_name)
         title = self.capitalize(title)
 
+        deprecated = param.deprecated
+        history = param.history
+
         methods = self.methods(key=key, method_title=title, external=name, description=description,
-                               param_name=short_name, param_values=param_values, type=type_name)
+                               param_name=short_name, param_values=param_values, type=type_name, 
+                               deprecated=deprecated, history=history)
         params = self.params(key=key, value="'{}'".format(param.name))
         return imports, methods, params
 

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -69,10 +69,10 @@ class InterfaceProducerCommon(ABC):
     @staticmethod
     def extract_values(param):
         p = OrderedDict() 
-        if hasattr(param.param_type, 'max_size'):
-            p['array_max_size'] = param.param_type.max_size
         if hasattr(param.param_type, 'min_size'):
-            p['array_min_size'] = param.param_type.min_size   
+            p['array_min_size'] = param.param_type.min_size  
+        if hasattr(param.param_type, 'max_size'):
+            p['array_max_size'] = param.param_type.max_size 
         if hasattr(param, 'default_value'):
             if hasattr(param.default_value, 'name'):
                 p['default_value'] = param.default_value.name
@@ -83,22 +83,22 @@ class InterfaceProducerCommon(ABC):
                 p['default_value'] = param.param_type.default_value.name
             else:  
                 p['default_value'] = param.param_type.default_value
-        if hasattr(param.param_type, 'max_value'):
-            p['num_max_value'] = param.param_type.max_value
-        elif hasattr(param.param_type, 'element_type') and hasattr(param.param_type.element_type, 'max_value'):
-            p['num_max_value'] = param.param_type.element_type.max_value
         if hasattr(param.param_type, 'min_value'):
             p['num_min_value'] = param.param_type.min_value
         elif hasattr(param.param_type, 'element_type') and hasattr(param.param_type.element_type, 'min_value'):
             p['num_min_value'] = param.param_type.element_type.min_value
-        if hasattr(param.param_type, 'max_length'):
-            p['string_max_length'] = param.param_type.max_length
-        elif hasattr(param.param_type, 'element_type') and hasattr(param.param_type.element_type, 'max_length'):
-            p['string_max_length'] = param.param_type.element_type.max_length
+        if hasattr(param.param_type, 'max_value'):
+            p['num_max_value'] = param.param_type.max_value
+        elif hasattr(param.param_type, 'element_type') and hasattr(param.param_type.element_type, 'max_value'):
+            p['num_max_value'] = param.param_type.element_type.max_value
         if hasattr(param.param_type, 'min_length'):
             p['string_min_length'] = param.param_type.min_length
         elif hasattr(param.param_type, 'element_type') and hasattr(param.param_type.element_type, 'min_length'):
             p['string_min_length'] = param.param_type.element_type.min_length
+        if hasattr(param.param_type, 'max_length'):
+            p['string_max_length'] = param.param_type.max_length
+        elif hasattr(param.param_type, 'element_type') and hasattr(param.param_type.element_type, 'max_length'):
+            p['string_max_length'] = param.param_type.element_type.max_length
 
         # Filter None values
         filtered_values = {k: v for k, v in p.items() if v is not None}

--- a/generator/transformers/enums_producer.py
+++ b/generator/transformers/enums_producer.py
@@ -24,7 +24,7 @@ class EnumsProducer(InterfaceProducerCommon):
         self._container_name = 'elements'
         self.logger = logging.getLogger(self.__class__.__name__)
         self.enum_class = paths.path_to_enum_class
-        self.methods = namedtuple('Methods', 'method_title description type')
+        self.methods = namedtuple('Methods', 'method_title description type deprecated')
 
     @property
     def container_name(self):
@@ -54,8 +54,8 @@ class EnumsProducer(InterfaceProducerCommon):
         type_name = self.extract_type(param)
         description = self.extract_description(description, 117 - len(type_name))
         name = self.ending_cutter(name)
-
-        methods = self.methods(method_title=name, description=description, type=type_name)
+        deprecated = param.deprecated
+        methods = self.methods(method_title=name, description=description, type=type_name, deprecated=deprecated)
         params = self.extract_param(param)
 
         imports = None

--- a/generator/transformers/functions_producer.py
+++ b/generator/transformers/functions_producer.py
@@ -2,9 +2,11 @@
 Functions transformation
 """
 import logging
-from collections import OrderedDict
+import textwrap
+from collections import namedtuple, OrderedDict
 
 from model.function import Function
+from model.param import Param
 from transformers.common_producer import InterfaceProducerCommon
 
 
@@ -54,4 +56,38 @@ class FunctionsProducer(InterfaceProducerCommon):
             render['extend'] = what_where.what
             render['imports'].add(what_where)
         render['imports'].add(self.imports(what='FunctionID', wherefrom='{}/FunctionID.js'.format(self.enums_dir)))
+
+        params = OrderedDict()
+        for param in getattr(item, self._container_name).values():
+            param.origin = param.name
+            param.name = self.replace_keywords(param.name)
+            p = self.extract_param(param)
+            params.update({param.name: p})
+        '''
+        if params:
+            render['params'] = tuple(params.values())
+        '''
         return render
+
+    def extract_param(self, param: Param):
+        p = OrderedDict()
+        p['title'] = param.name[:1].upper() + param.name[1:]
+        p['key'] = 'KEY_' + self.key(param.name)
+        p['mandatory'] = param.is_mandatory
+        p['last'] = param.name
+        if param.since:
+            p['since'] = param.since
+        p['deprecated'] = param.deprecated
+        p['origin'] = param.origin
+        p['values'] = self.extract_values(param)
+        d = self.extract_description(param.description)
+        if param.name == 'success':
+            d = 'whether the request is successfully processed'
+        if param.name == 'resultCode':
+            d = 'additional information about a response returning a failed outcome'
+        '''
+        if d:
+            p['description'] = textwrap.wrap(d, 90)
+        '''
+        Params = namedtuple('Params', sorted(p))
+        return Params(**p)

--- a/generator/transformers/functions_producer.py
+++ b/generator/transformers/functions_producer.py
@@ -63,10 +63,6 @@ class FunctionsProducer(InterfaceProducerCommon):
             param.name = self.replace_keywords(param.name)
             p = self.extract_param(param)
             params.update({param.name: p})
-        '''
-        if params:
-            render['params'] = tuple(params.values())
-        '''
         return render
 
     def extract_param(self, param: Param):
@@ -85,9 +81,5 @@ class FunctionsProducer(InterfaceProducerCommon):
             d = 'whether the request is successfully processed'
         if param.name == 'resultCode':
             d = 'additional information about a response returning a failed outcome'
-        '''
-        if d:
-            p['description'] = textwrap.wrap(d, 90)
-        '''
         Params = namedtuple('Params', sorted(p))
         return Params(**p)


### PR DESCRIPTION
Fixes #296 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run the `npm run build` command to run the generator and check a deprecated enum value.

### Summary
Adds deprecated flags to the JS docs of deprecated enum values. This PR is dependent on the changes [here](https://github.com/smartdevicelink/sdl_javascript_suite/pull/295) and should be reviewed after those are approved.