### PR TITLE
Update for Main Menu updating and Pagination

### DIFF
--- a/lib/js/src/rpc/RpcCreator.js
+++ b/lib/js/src/rpc/RpcCreator.js
@@ -105,6 +105,7 @@ import { OnInteriorVehicleData } from './messages/OnInteriorVehicleData.js';
 import { OnKeyboardInput } from './messages/OnKeyboardInput.js';
 import { OnLanguageChange } from './messages/OnLanguageChange.js';
 import { OnPermissionsChange } from './messages/OnPermissionsChange.js';
+import { OnSubtleAlertPressed } from './messages/OnSubtleAlertPressed.js';
 import { OnRCStatus } from './messages/OnRCStatus.js';
 import { OnSystemCapabilityUpdated } from './messages/OnSystemCapabilityUpdated.js';
 import { OnSystemRequest } from './messages/OnSystemRequest.js';
@@ -166,6 +167,8 @@ import { SubscribeVehicleData } from './messages/SubscribeVehicleData.js';
 import { SubscribeVehicleDataResponse } from './messages/SubscribeVehicleDataResponse.js';
 import { SubscribeWayPoints } from './messages/SubscribeWayPoints.js';
 import { SubscribeWayPointsResponse } from './messages/SubscribeWayPointsResponse.js';
+import { SubtleAlert } from './messages/SubtleAlert.js';
+import { SubtleAlertResponse } from './messages/SubtleAlertResponse.js';
 import { SystemRequest } from './messages/SystemRequest.js';
 import { SystemRequestResponse } from './messages/SystemRequestResponse.js';
 import { UnpublishAppService } from './messages/UnpublishAppService.js';
@@ -322,6 +325,18 @@ class RpcCreator {
                     message = new Show(params);
                 } else if (messageType === MessageType.response) {
                     message = new ShowResponse(params);
+                }
+                break;
+            case FunctionID.SubtleAlert:
+                if (messageType === MessageType.request) {
+                    message = new SubtleAlert(params);
+                } else if (messageType === MessageType.response) {
+                    message = new SubtleAlertResponse(params);
+                }
+                break;
+            case FunctionID.OnSubtleAlertPressed:
+                if (messageType === MessageType.notification) {
+                    message = new OnSubtleAlertPressed(params);
                 }
                 break;
             case FunctionID.Speak:

--- a/lib/js/src/rpc/RpcCreator.js
+++ b/lib/js/src/rpc/RpcCreator.js
@@ -105,8 +105,8 @@ import { OnInteriorVehicleData } from './messages/OnInteriorVehicleData.js';
 import { OnKeyboardInput } from './messages/OnKeyboardInput.js';
 import { OnLanguageChange } from './messages/OnLanguageChange.js';
 import { OnPermissionsChange } from './messages/OnPermissionsChange.js';
-import { OnSubtleAlertPressed } from './messages/OnSubtleAlertPressed.js';
 import { OnRCStatus } from './messages/OnRCStatus.js';
+import { OnSubtleAlertPressed } from './messages/OnSubtleAlertPressed.js';
 import { OnSystemCapabilityUpdated } from './messages/OnSystemCapabilityUpdated.js';
 import { OnSystemRequest } from './messages/OnSystemRequest.js';
 import { OnTBTClientState } from './messages/OnTBTClientState.js';
@@ -320,13 +320,6 @@ class RpcCreator {
                     message = new AlertResponse(params);
                 }
                 break;
-            case FunctionID.Show:
-                if (messageType === MessageType.request) {
-                    message = new Show(params);
-                } else if (messageType === MessageType.response) {
-                    message = new ShowResponse(params);
-                }
-                break;
             case FunctionID.SubtleAlert:
                 if (messageType === MessageType.request) {
                     message = new SubtleAlert(params);
@@ -337,6 +330,13 @@ class RpcCreator {
             case FunctionID.OnSubtleAlertPressed:
                 if (messageType === MessageType.notification) {
                     message = new OnSubtleAlertPressed(params);
+                }
+                break;
+            case FunctionID.Show:
+                if (messageType === MessageType.request) {
+                    message = new Show(params);
+                } else if (messageType === MessageType.response) {
+                    message = new ShowResponse(params);
                 }
                 break;
             case FunctionID.Speak:

--- a/lib/js/src/rpc/RpcCreator.js
+++ b/lib/js/src/rpc/RpcCreator.js
@@ -106,11 +106,12 @@ import { OnKeyboardInput } from './messages/OnKeyboardInput.js';
 import { OnLanguageChange } from './messages/OnLanguageChange.js';
 import { OnPermissionsChange } from './messages/OnPermissionsChange.js';
 import { OnRCStatus } from './messages/OnRCStatus.js';
-import { OnSubtleAlertPressed } from './messages/OnSubtleAlertPressed.js';
 import { OnSystemCapabilityUpdated } from './messages/OnSystemCapabilityUpdated.js';
 import { OnSystemRequest } from './messages/OnSystemRequest.js';
 import { OnTBTClientState } from './messages/OnTBTClientState.js';
 import { OnTouchEvent } from './messages/OnTouchEvent.js';
+import { OnUpdateFile } from './messages/OnUpdateFile.js';
+import { OnUpdateSubMenu } from './messages/OnUpdateSubMenu.js';
 import { OnVehicleData } from './messages/OnVehicleData.js';
 import { OnWayPointChange } from './messages/OnWayPointChange.js';
 import { PerformAppServiceInteraction } from './messages/PerformAppServiceInteraction.js';
@@ -165,8 +166,6 @@ import { SubscribeVehicleData } from './messages/SubscribeVehicleData.js';
 import { SubscribeVehicleDataResponse } from './messages/SubscribeVehicleDataResponse.js';
 import { SubscribeWayPoints } from './messages/SubscribeWayPoints.js';
 import { SubscribeWayPointsResponse } from './messages/SubscribeWayPointsResponse.js';
-import { SubtleAlert } from './messages/SubtleAlert.js';
-import { SubtleAlertResponse } from './messages/SubtleAlertResponse.js';
 import { SystemRequest } from './messages/SystemRequest.js';
 import { SystemRequestResponse } from './messages/SystemRequestResponse.js';
 import { UnpublishAppService } from './messages/UnpublishAppService.js';
@@ -316,18 +315,6 @@ class RpcCreator {
                     message = new Alert(params);
                 } else if (messageType === MessageType.response) {
                     message = new AlertResponse(params);
-                }
-                break;
-            case FunctionID.SubtleAlert:
-                if (messageType === MessageType.request) {
-                    message = new SubtleAlert(params);
-                } else if (messageType === MessageType.response) {
-                    message = new SubtleAlertResponse(params);
-                }
-                break;
-            case FunctionID.OnSubtleAlertPressed:
-                if (messageType === MessageType.notification) {
-                    message = new OnSubtleAlertPressed(params);
                 }
                 break;
             case FunctionID.Show:
@@ -755,6 +742,16 @@ class RpcCreator {
             case FunctionID.OnSystemCapabilityUpdated:
                 if (messageType === MessageType.notification) {
                     message = new OnSystemCapabilityUpdated(params);
+                }
+                break;
+            case FunctionID.OnUpdateFile:
+                if (messageType === MessageType.notification) {
+                    message = new OnUpdateFile(params);
+                }
+                break;
+            case FunctionID.OnUpdateSubMenu:
+                if (messageType === MessageType.notification) {
+                    message = new OnUpdateSubMenu(params);
                 }
                 break;
             case FunctionID.EncodedSyncPData:

--- a/lib/js/src/rpc/enums/FunctionID.js
+++ b/lib/js/src/rpc/enums/FunctionID.js
@@ -553,6 +553,14 @@ class FunctionID extends Enum {
     }
 
     /**
+     * Get the enum value for SubtleAlert.
+     * @returns {Number} - The enum value.
+     */
+    static get SubtleAlert () {
+        return FunctionID._MAP.SubtleAlert;
+    }
+
+    /**
      * Get the enum value for OnHMIStatus.
      * @returns {Number} - The enum value.
      */
@@ -729,6 +737,14 @@ class FunctionID extends Enum {
     }
 
     /**
+     * Get the enum value for OnSubtleAlertPressed.
+     * @returns {Number} - The enum value.
+     */
+    static get OnSubtleAlertPressed () {
+        return FunctionID._MAP.OnSubtleAlertPressed;
+    }
+
+    /**
      * Get the enum value for EncodedSyncPData.
      * @returns {Number} - The enum value.
      */
@@ -843,6 +859,7 @@ FunctionID._MAP = Object.freeze({
     'DeleteWindow': 0x3D,
     'GetInteriorVehicleDataConsent': 0x3E,
     'ReleaseInteriorVehicleDataModule': 0x3F,
+    'SubtleAlert': 0x40,
     'OnHMIStatus': 0x8000,
     'OnAppInterfaceUnregistered': 0x8001,
     'OnButtonEvent': 0x8002,
@@ -863,6 +880,7 @@ FunctionID._MAP = Object.freeze({
     'OnRCStatus': 0x8011,
     'OnAppServiceData': 0x8012,
     'OnSystemCapabilityUpdated': 0x8013,
+    'OnSubtleAlertPressed': 0x8014,
     'OnUpdateFile': 0x8015,
     'OnUpdateSubMenu': 0x8016,
     'EncodedSyncPData': 0x10000,

--- a/lib/js/src/rpc/enums/FunctionID.js
+++ b/lib/js/src/rpc/enums/FunctionID.js
@@ -553,14 +553,6 @@ class FunctionID extends Enum {
     }
 
     /**
-     * Get the enum value for SubtleAlert.
-     * @returns {Number} - The enum value.
-     */
-    static get SubtleAlert () {
-        return FunctionID._MAP.SubtleAlert;
-    }
-
-    /**
      * Get the enum value for OnHMIStatus.
      * @returns {Number} - The enum value.
      */
@@ -721,11 +713,19 @@ class FunctionID extends Enum {
     }
 
     /**
-     * Get the enum value for OnSubtleAlertPressed.
+     * Get the enum value for OnUpdateFile.
      * @returns {Number} - The enum value.
      */
-    static get OnSubtleAlertPressed () {
-        return FunctionID._MAP.OnSubtleAlertPressed;
+    static get OnUpdateFile () {
+        return FunctionID._MAP.OnUpdateFile;
+    }
+
+    /**
+     * Get the enum value for OnUpdateSubMenu.
+     * @returns {Number} - The enum value.
+     */
+    static get OnUpdateSubMenu () {
+        return FunctionID._MAP.OnUpdateSubMenu;
     }
 
     /**
@@ -843,7 +843,6 @@ FunctionID._MAP = Object.freeze({
     'DeleteWindow': 0x3D,
     'GetInteriorVehicleDataConsent': 0x3E,
     'ReleaseInteriorVehicleDataModule': 0x3F,
-    'SubtleAlert': 0x40,
     'OnHMIStatus': 0x8000,
     'OnAppInterfaceUnregistered': 0x8001,
     'OnButtonEvent': 0x8002,
@@ -864,7 +863,8 @@ FunctionID._MAP = Object.freeze({
     'OnRCStatus': 0x8011,
     'OnAppServiceData': 0x8012,
     'OnSystemCapabilityUpdated': 0x8013,
-    'OnSubtleAlertPressed': 0x8014,
+    'OnUpdateFile': 0x8015,
+    'OnUpdateSubMenu': 0x8016,
     'EncodedSyncPData': 0x10000,
     'SyncPData': 0x10001,
     'OnEncodedSyncPData': 0x18000,

--- a/lib/js/src/rpc/enums/ImageFieldName.js
+++ b/lib/js/src/rpc/enums/ImageFieldName.js
@@ -179,6 +179,15 @@ class ImageFieldName extends Enum {
      */
     static get subtleAlertIcon () {
         return ImageFieldName._MAP.subtleAlertIcon;
+     }
+
+    /**
+     * Get the enum value for subMenuIcon.
+     * The image field for AddSubMenu.menuIcon
+     * @returns {String} - The enum value.
+     */
+    static get subMenuIcon () {
+        return ImageFieldName._MAP.subMenuIcon;
     }
 
     /**
@@ -216,6 +225,7 @@ ImageFieldName._MAP = Object.freeze({
     'locationImage': 'locationImage',
     'alertIcon': 'alertIcon',
     'subtleAlertIcon': 'subtleAlertIcon',
+    'subMenuIcon': 'subMenuIcon',
 });
 
 export { ImageFieldName };

--- a/lib/js/src/rpc/enums/ImageFieldName.js
+++ b/lib/js/src/rpc/enums/ImageFieldName.js
@@ -173,15 +173,6 @@ class ImageFieldName extends Enum {
     }
 
     /**
-     * Get the enum value for subtleAlertIcon.
-     * The image of the subtle alert; applies to `SubtleAlert` `alertIcon`
-     * @returns {String} - The enum value.
-     */
-    static get subtleAlertIcon () {
-        return ImageFieldName._MAP.subtleAlertIcon;
-     }
-
-    /**
      * Get the enum value for subMenuIcon.
      * The image field for AddSubMenu.menuIcon
      * @returns {String} - The enum value.
@@ -224,7 +215,6 @@ ImageFieldName._MAP = Object.freeze({
     'showConstantTBTNextTurnIcon': 'showConstantTBTNextTurnIcon',
     'locationImage': 'locationImage',
     'alertIcon': 'alertIcon',
-    'subtleAlertIcon': 'subtleAlertIcon',
     'subMenuIcon': 'subMenuIcon',
 });
 

--- a/lib/js/src/rpc/enums/ImageFieldName.js
+++ b/lib/js/src/rpc/enums/ImageFieldName.js
@@ -173,6 +173,15 @@ class ImageFieldName extends Enum {
     }
 
     /**
+     * Get the enum value for subtleAlertIcon.
+     * The image of the subtle alert; applies to `SubtleAlert` `alertIcon`
+     * @returns {String} - The enum value.
+     */
+    static get subtleAlertIcon () {
+        return ImageFieldName._MAP.subtleAlertIcon;
+    }
+
+    /**
      * Get the enum value for subMenuIcon.
      * The image field for AddSubMenu.menuIcon
      * @returns {String} - The enum value.
@@ -215,6 +224,7 @@ ImageFieldName._MAP = Object.freeze({
     'showConstantTBTNextTurnIcon': 'showConstantTBTNextTurnIcon',
     'locationImage': 'locationImage',
     'alertIcon': 'alertIcon',
+    'subtleAlertIcon': 'subtleAlertIcon',
     'subMenuIcon': 'subMenuIcon',
 });
 

--- a/lib/js/src/rpc/messages/OnUpdateFile.js
+++ b/lib/js/src/rpc/messages/OnUpdateFile.js
@@ -1,0 +1,72 @@
+/* eslint-disable camelcase */
+/*
+* Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following
+* disclaimer in the documentation and/or other materials provided with the
+* distribution.
+*
+* Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+* its contributors may be used to endorse or promote products derived
+* from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import { FunctionID } from '../enums/FunctionID.js';
+import { RpcNotification } from '../RpcNotification.js';
+
+/**
+ * This notification tells an app to upload and update a file with a given name.
+ */
+class OnUpdateFile extends RpcNotification {
+    /**
+     * Initalizes an instance of OnUpdateFile.
+     * @class
+     * @param {object} parameters - An object map of parameters.
+     */
+    constructor (parameters) {
+        super(parameters);
+        this.setFunctionId(FunctionID.OnUpdateFile);
+    }
+
+    /**
+     * Set the FileName
+     * @param {String} name - File reference name. - The desired FileName.
+     * @returns {OnUpdateFile} - The class instance for method chaining.
+     */
+    setFileName (name) {
+        this.setParameter(OnUpdateFile.KEY_FILE_NAME, name);
+        return this;
+    }
+
+    /**
+     * Get the FileName
+     * @returns {String} - the KEY_FILE_NAME value
+     */
+    getFileName () {
+        return this.getParameter(OnUpdateFile.KEY_FILE_NAME);
+    }
+}
+
+OnUpdateFile.KEY_FILE_NAME = 'fileName';
+
+export { OnUpdateFile };

--- a/lib/js/src/rpc/messages/OnUpdateSubMenu.js
+++ b/lib/js/src/rpc/messages/OnUpdateSubMenu.js
@@ -1,0 +1,94 @@
+/* eslint-disable camelcase */
+/*
+* Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following
+* disclaimer in the documentation and/or other materials provided with the
+* distribution.
+*
+* Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+* its contributors may be used to endorse or promote products derived
+* from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import { FunctionID } from '../enums/FunctionID.js';
+import { RpcNotification } from '../RpcNotification.js';
+
+/**
+ * This notification tells an app to update the AddSubMenu or its 'sub' AddCommand and AddSubMenus with the requested
+ * data
+ */
+class OnUpdateSubMenu extends RpcNotification {
+    /**
+     * Initalizes an instance of OnUpdateSubMenu.
+     * @class
+     * @param {object} parameters - An object map of parameters.
+     */
+    constructor (parameters) {
+        super(parameters);
+        this.setFunctionId(FunctionID.OnUpdateSubMenu);
+    }
+
+    /**
+     * Set the MenuID
+     * @param {Number} id - This menuID must match a menuID in the current menu structure - The desired MenuID.
+     * @returns {OnUpdateSubMenu} - The class instance for method chaining.
+     */
+    setMenuID (id) {
+        this.setParameter(OnUpdateSubMenu.KEY_MENU_ID, id);
+        return this;
+    }
+
+    /**
+     * Get the MenuID
+     * @returns {Number} - the KEY_MENU_ID value
+     */
+    getMenuID () {
+        return this.getParameter(OnUpdateSubMenu.KEY_MENU_ID);
+    }
+
+    /**
+     * Set the UpdateSubCells
+     * @param {Boolean} cells - If not set, assume false. If true, the app should send AddCommands with parentIDs - The desired UpdateSubCells.
+     * matching the menuID. These AddCommands will then be attached to the submenu and
+     * displayed if the submenu is selected.
+     * @returns {OnUpdateSubMenu} - The class instance for method chaining.
+     */
+    setUpdateSubCells (cells) {
+        this.setParameter(OnUpdateSubMenu.KEY_UPDATE_SUB_CELLS, cells);
+        return this;
+    }
+
+    /**
+     * Get the UpdateSubCells
+     * @returns {Boolean} - the KEY_UPDATE_SUB_CELLS value
+     */
+    getUpdateSubCells () {
+        return this.getParameter(OnUpdateSubMenu.KEY_UPDATE_SUB_CELLS);
+    }
+}
+
+OnUpdateSubMenu.KEY_MENU_ID = 'menuID';
+OnUpdateSubMenu.KEY_UPDATE_SUB_CELLS = 'updateSubCells';
+
+export { OnUpdateSubMenu };

--- a/lib/js/src/rpc/structs/DynamicUpdateCapabilities.js
+++ b/lib/js/src/rpc/structs/DynamicUpdateCapabilities.js
@@ -1,0 +1,96 @@
+/* eslint-disable camelcase */
+/*
+* Copyright (c) 2020, SmartDeviceLink Consortium, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following
+* disclaimer in the documentation and/or other materials provided with the
+* distribution.
+*
+* Neither the name of the SmartDeviceLink Consortium Inc. nor the names of
+* its contributors may be used to endorse or promote products derived
+* from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import { ImageFieldName } from '../enums/ImageFieldName.js';
+import { RpcStruct } from '../RpcStruct.js';
+
+class DynamicUpdateCapabilities extends RpcStruct {
+    /**
+     * Initalizes an instance of DynamicUpdateCapabilities.
+     * @class
+     * @param {object} parameters - An object map of parameters.
+     */
+    constructor (parameters) {
+        super(parameters);
+    }
+
+    /**
+     * Set the SupportedDynamicImageFieldNames
+     * @param {ImageFieldName[]} names - An array of ImageFieldName values for which the system supports sending - The desired SupportedDynamicImageFieldNames.
+     * OnFileUpdate notifications. If you send an Image struct for that image field
+     * with a name without having uploaded the image data using PutFile that matches
+     * that name, the system will request that you upload the data with PutFile at a
+     * later point when the HMI needs it. The HMI will then display the image in the
+     * appropriate field. If not sent, assume false.
+     * @returns {DynamicUpdateCapabilities} - The class instance for method chaining.
+     */
+    setSupportedDynamicImageFieldNames (names) {
+        this._validateType(ImageFieldName, names, true);
+        this.setParameter(DynamicUpdateCapabilities.KEY_SUPPORTED_DYNAMIC_IMAGE_FIELD_NAMES, names);
+        return this;
+    }
+
+    /**
+     * Get the SupportedDynamicImageFieldNames
+     * @returns {ImageFieldName[]} - the KEY_SUPPORTED_DYNAMIC_IMAGE_FIELD_NAMES value
+     */
+    getSupportedDynamicImageFieldNames () {
+        return this.getObject(ImageFieldName, DynamicUpdateCapabilities.KEY_SUPPORTED_DYNAMIC_IMAGE_FIELD_NAMES);
+    }
+
+    /**
+     * Set the SupportsDynamicSubMenus
+     * @param {Boolean} menus - If true, the head unit supports dynamic sub-menus by sending OnUpdateSubMenu - The desired SupportsDynamicSubMenus.
+     * notifications. If true, you should not send AddCommands that attach to a parentID for an
+     * AddSubMenu until OnUpdateSubMenu is received with the menuID. At that point, you should
+     * send all AddCommands with a parentID that match the menuID. If not set, assume false.
+     * @returns {DynamicUpdateCapabilities} - The class instance for method chaining.
+     */
+    setSupportsDynamicSubMenus (menus) {
+        this.setParameter(DynamicUpdateCapabilities.KEY_SUPPORTS_DYNAMIC_SUB_MENUS, menus);
+        return this;
+    }
+
+    /**
+     * Get the SupportsDynamicSubMenus
+     * @returns {Boolean} - the KEY_SUPPORTS_DYNAMIC_SUB_MENUS value
+     */
+    getSupportsDynamicSubMenus () {
+        return this.getParameter(DynamicUpdateCapabilities.KEY_SUPPORTS_DYNAMIC_SUB_MENUS);
+    }
+}
+
+DynamicUpdateCapabilities.KEY_SUPPORTED_DYNAMIC_IMAGE_FIELD_NAMES = 'supportedDynamicImageFieldNames';
+DynamicUpdateCapabilities.KEY_SUPPORTS_DYNAMIC_SUB_MENUS = 'supportsDynamicSubMenus';
+
+export { DynamicUpdateCapabilities };

--- a/lib/js/src/rpc/structs/WindowCapability.js
+++ b/lib/js/src/rpc/structs/WindowCapability.js
@@ -32,6 +32,7 @@
 */
 
 import { ButtonCapabilities } from './ButtonCapabilities.js';
+import { DynamicUpdateCapabilities } from './DynamicUpdateCapabilities.js';
 import { ImageField } from './ImageField.js';
 import { ImageType } from '../enums/ImageType.js';
 import { MenuLayout } from '../enums/MenuLayout.js';
@@ -220,6 +221,26 @@ class WindowCapability extends RpcStruct {
     getMenuLayoutsAvailable () {
         return this.getObject(MenuLayout, WindowCapability.KEY_MENU_LAYOUTS_AVAILABLE);
     }
+
+    /**
+     * Set the DynamicUpdateCapabilities
+     * @param {DynamicUpdateCapabilities} capabilities - Contains the head unit's capabilities for dynamic updating - The desired DynamicUpdateCapabilities.
+     * features declaring if the module will send dynamic update RPCs.
+     * @returns {WindowCapability} - The class instance for method chaining.
+     */
+    setDynamicUpdateCapabilities (capabilities) {
+        this._validateType(DynamicUpdateCapabilities, capabilities);
+        this.setParameter(WindowCapability.KEY_DYNAMIC_UPDATE_CAPABILITIES, capabilities);
+        return this;
+    }
+
+    /**
+     * Get the DynamicUpdateCapabilities
+     * @returns {DynamicUpdateCapabilities} - the KEY_DYNAMIC_UPDATE_CAPABILITIES value
+     */
+    getDynamicUpdateCapabilities () {
+        return this.getObject(DynamicUpdateCapabilities, WindowCapability.KEY_DYNAMIC_UPDATE_CAPABILITIES);
+    }
 }
 
 WindowCapability.KEY_WINDOW_ID = 'windowID';
@@ -231,5 +252,6 @@ WindowCapability.KEY_NUM_CUSTOM_PRESETS_AVAILABLE = 'numCustomPresetsAvailable';
 WindowCapability.KEY_BUTTON_CAPABILITIES = 'buttonCapabilities';
 WindowCapability.KEY_SOFT_BUTTON_CAPABILITIES = 'softButtonCapabilities';
 WindowCapability.KEY_MENU_LAYOUTS_AVAILABLE = 'menuLayoutsAvailable';
+WindowCapability.KEY_DYNAMIC_UPDATE_CAPABILITIES = 'dynamicUpdateCapabilities';
 
 export { WindowCapability };


### PR DESCRIPTION
Fixes #268 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Use the example app and add listeners for the new `OnUpdateFile` and `OnUpdateSubMenu` notifications. Then send an `AddSubMenu` RPC with an icon that does not exist ('not_real.png'). When viewing the menu item, observe both new notifications as they come in. Additionally, check the new capability by checking a window capability in the SCM.

### Summary
Adds the dynamicUpdateCapability to the WindowCapability and introduces the new OnUpdateFile and OnUpdateSubMenu notifications.