### PR TITLE
Add reason param to NAKBase and update protocol to v5.3.0

### DIFF
--- a/lib/js/src/protocol/_SdlProtocolBase.js
+++ b/lib/js/src/protocol/_SdlProtocolBase.js
@@ -584,6 +584,6 @@ _SdlProtocolBase.V3_V4_MTU_SIZE = 131072;
 /**
  * Max supported protocol version in this release of the library
  */
-_SdlProtocolBase.MAX_PROTOCOL_VERSION = new Version(5, 2, 0);
+_SdlProtocolBase.MAX_PROTOCOL_VERSION = new Version(5, 3, 0);
 
 export { _SdlProtocolBase };

--- a/lib/js/src/protocol/_SdlProtocolBase.js
+++ b/lib/js/src/protocol/_SdlProtocolBase.js
@@ -358,12 +358,16 @@ class _SdlProtocolBase {
         } else if (frameInfo === _SdlPacket.FRAME_INFO_START_SERVICE_ACK) {
             this._handleStartServiceACK(sdlPacket);
         } else if (frameInfo === _SdlPacket.FRAME_INFO_START_SERVICE_NAK) {
+            const reason = sdlPacket.getTag(_ControlFrameTags.RPC.StartServiceNAK.REASON);
+            console.warn(reason);
             this._handleStartServiceNAK(sdlPacket);
         } else if (frameInfo === _SdlPacket.FRAME_INFO_END_SERVICE_ACK) {
             this._handleEndServiceACK(sdlPacket);
         } else if (frameInfo === _SdlPacket.FRAME_INFO_END_SERVICE) {
             this._handleEndService(sdlPacket);
         } else if (frameInfo === _SdlPacket.FRAME_INFO_END_SERVICE_NAK) {
+            const reason = sdlPacket.getTag(_ControlFrameTags.RPC.StartServiceNAK.REASON);
+            console.warn(reason);
             this._handleEndServiceNAK(sdlPacket);
         } else {
             console.warn('Unhandled control packet', { frameInfo });

--- a/lib/js/src/protocol/enums/_ControlFrameTags.js
+++ b/lib/js/src/protocol/enums/_ControlFrameTags.js
@@ -41,6 +41,7 @@ const StartServiceACKBase = {
 
 const NAKBase = {
     REJECTED_PARAMS: 'rejectedParams',
+    REASON: 'reason',
 };
 
 const StartServiceProtocolVersion = {
@@ -90,9 +91,7 @@ _ControlFrameTags.RPC = Object.freeze({
 
     RegisterSecondaryTransportACK: {},
 
-    RegisterSecondaryTransportNAK: Object.assign({
-        REASON: 'reason',
-    }, NAKBase),
+    RegisterSecondaryTransportNAK: NAKBase,
 });
 
 _ControlFrameTags.Audio = Object.freeze({


### PR DESCRIPTION
Fixes #243 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Use the following code snippet to start services that will be used to trigger a NAK. This can be done from any of the example apps.
```
const session = this._sdlManager._lifecycleManager._sdlSession;
// serviceType is one of [Audio, Video, RPC]
// isProtected is whether the service should be protected
session.startService(SDL.protocol.enums._ServiceType[serviceType], session.getSessionId(), isProtected);
```
The previous snippet can be used to trigger a StartServiceNAK. To observe the new reason param in the NAK, modify the _SdlProtocolBase's _handleStartServiceNAK method to match the following code snippet.
```
const serviceType = sdlPacket.getServiceType();
const protocolVersion = sdlPacket.getVersion();
if (protocolVersion >= 5) {
    let rejectedTag = null;
    if (serviceType === _ServiceType.AUDIO) {
        rejectedTag = _ControlFrameTags.Audio.StartServiceNAK.REASON;
    } else if (serviceType === _ServiceType.VIDEO) {
        rejectedTag = _ControlFrameTags.Video.StartServiceNAK.REASON;
    }
    const reason = sdlPacket.getTag(rejectedTag);
    console.error('Got StartServiceNAK with reason', reason);
}
```

### Summary
Add reason param to NAKBase class and update protocol version to v5.3.0.