### PR TITLE
Add extra queue functionality for manager use

### DIFF
--- a/lib/js/src/manager/_SubManagerBase.js
+++ b/lib/js/src/manager/_SubManagerBase.js
@@ -31,6 +31,7 @@
 */
 
 import { HMILevel } from '../rpc/enums/HMILevel.js';
+import { _Task } from './_Task.js';
 import { FunctionID } from '../rpc/enums/FunctionID.js';
 import { PredefinedWindows } from '../rpc/enums/PredefinedWindows.js';
 import { SystemCapabilityType } from '../rpc/enums/SystemCapabilityType.js';
@@ -206,14 +207,47 @@ class _SubManagerBase {
     /**
      * Adds an async function to the queue
      * @private
-     * @param {Promise} task - A promise to add to the task queue.
+     * @param {_Task} task - A task to add to the task queue.
      */
     _addTask (task) {
         if (!this._isHandlingTasks) {
             return;
         }
-        this._taskQueue.push(task);
+        // check the priority value of the task and insert it into the queue in the correct location
+        // the task must go to the bottom of the set of tasks with the same priority value,
+        // or under a task with the next highest priority value if there are no ties.
+        let insertIndex = this._taskQueue.length;
+        let taskAtIndex = this._taskQueue[insertIndex - 1] ? this._taskQueue[insertIndex - 1] : null;
+        while (insertIndex > 0 && taskAtIndex !== null && taskAtIndex.getPriority() < task.getPriority()) {
+            insertIndex--;
+            taskAtIndex = this._taskQueue[insertIndex - 1] ? this._taskQueue[insertIndex - 1] : null;
+        }
+        // insert the task
+        this._taskQueue.splice(insertIndex, 0, task);
+
         this._invokeTaskQueue();
+    }
+
+    /**
+     * Returns the task queue
+     * @private
+     * @returns {_Task[]} - The list of tasks.
+     */
+    _getTasks () {
+        return this._taskQueue;
+    }
+
+    /**
+     * Sets all selected tasks to be cancelled which will prevent them from running
+     * @param {String} name - An optional name to pass in which will only cancel tasks with matching names.
+     * @private
+     */
+    _cancelAllTasks (name = null) {
+        this._taskQueue.forEach(task => {
+            if (name === null || task.getName() === name) {
+                task.switchStates(_Task.CANCELED);
+            }
+        });
     }
 
     /**
@@ -229,14 +263,30 @@ class _SubManagerBase {
             return;
         }
 
+        // do not pop the task yet. if it's blocked it should stay in the queue
+        if (this._taskQueue[0].getState() === _Task.BLOCKED) {
+            // the task is blocking the queue! now the queue must wait until another task comes in
+            return;
+        }
+
         this._isTaskRunning = true;
 
         const currentTask = this._taskQueue.shift();
-        await currentTask(this._taskQueue) // the task has access to the task queue as an argument
+        if (currentTask.getState() === _Task.CANCELED) {
+            // run this method again for potential future tasks
+            this._isTaskRunning = false;
+            return this._invokeTaskQueue();
+        }
+
+        const taskPromise = currentTask.run()
             .catch(err => { // something happened. log the error and continue
                 console.error(err);
                 return;
             });
+
+        if (!currentTask.getIsConcurrent()) {
+            await taskPromise; // wait for the task to complete before continuing
+        }
 
         this._isTaskRunning = false;
 

--- a/lib/js/src/manager/_Task.js
+++ b/lib/js/src/manager/_Task.js
@@ -1,0 +1,186 @@
+/* eslint-disable no-unused-vars */
+
+/*
+* Copyright (c) 2020, Livio, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following
+* disclaimer in the documentation and/or other materials provided with the
+* distribution.
+*
+* Neither the name of the Livio Inc. nor the names of its contributors
+* may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import { _uuid } from '../util/_uuid.js';
+
+/**
+ * A class representing a controllable asynchronous operation to be performed in a queue
+ * @private
+ */
+class _Task {
+    /**
+     * Initializes an instance of _Task.
+     * @class
+     */
+    constructor (name = null) {
+        this._state = READY;
+        this._callback = null;
+        this._id = _uuid(); // generate an id for every task
+        this._isConcurrent = false; // whether this task can be run without waiting for completion
+        this._priority = 0; // the priority value for this task. higher value means it should be started sooner
+        this._name = name; // a name to give to the task. does not need to be unique
+    }
+
+    /**
+     * Changes the state of the task.
+     * @param {Number} newState - One of the _Task static values which represent the task's state
+     */
+    switchStates (newState) {
+        const oldState = this._state;
+        this._state = newState;
+        if (typeof this._callback === 'function') {
+            this._callback(oldState, newState);
+        }
+    }
+
+    /**
+     * Attempts to run the task
+     */
+    async run () {
+        if (this._state !== READY) {
+            throw new Error(`run() called while not in state READY. Actual state: ${this._state}`);
+        }
+        this.switchStates(IN_PROGRESS);
+        await this.onExecute(this);
+        if (this._state !== CANCELED && this._state !== ERROR) {
+            this.switchStates(FINISHED);
+        }
+    }
+
+    /**
+     * The method that causes the task to run. Must be overridden by anything that extends _Task
+     * @param {_Task} task - The task instance, so that the running function can reference it
+     * @abstract
+     */
+    onExecute (task) {
+        throw new Error('onExecute method must be overridden');
+    }
+
+    /**
+     * Set the callback value.
+     * @param {Function} callback - A callback function that gets passed the change of this task's state
+     * @returns {_Task} - A reference of this class to support method chaining.
+     */
+    setCallback (callback) {
+        this._callback = callback;
+        return this;
+    }
+
+    /**
+     * Get the callback value.
+     * @returns {Function} - A callback function that gets passed the change of this task's state.
+     */
+    getCallback () {
+        return this._callback;
+    }
+
+    /**
+     * Get the state value.
+     * @returns {Number} - One of the _Task static values which represent the task's state
+     */
+    getState () {
+        return this._state;
+    }
+
+    /**
+     * Get the unique id value.
+     * @returns {String} - The assigned unique id for this task
+     */
+    getId () {
+        return this._id;
+    }
+
+    /**
+     * Set the concurrency flag.
+     * @param {Boolean} isConcurrent - Whether this task can be run without waiting for completion.
+     * @returns {_Task} - A reference of this class to support method chaining.
+     */
+    setIsConcurrent (isConcurrent) {
+        this._isConcurrent = isConcurrent;
+        return this;
+    }
+
+    /**
+     * Get the concurrency flag.
+     * @returns {Boolean} - Whether this task can be run without waiting for completion.
+     */
+    getIsConcurrent () {
+        return this._isConcurrent;
+    }
+
+    /**
+     * Set the priority value.
+     * @param {Number} priority - The priority value.
+     * @returns {_Task} - A reference of this class to support method chaining.
+     */
+    setPriority (priority) {
+        this._priority = priority;
+        return this;
+    }
+
+    /**
+     * Get the priority value.
+     * @returns {Number} - The priority value.
+     */
+    getPriority () {
+        return this._priority;
+    }
+
+    /**
+     * Set the name value.
+     * @param {String} name - The name value.
+     * @returns {_Task} - A reference of this class to support method chaining.
+     */
+    setName (name) {
+        this._name = name;
+        return this;
+    }
+
+    /**
+     * Get the name value.
+     * @returns {String} - The name value.
+     */
+    getName () {
+        return this._name;
+    }
+}
+
+const BLOCKED = _Task.BLOCKED = 0x00; // The state to use when the task cannot be ran or removed from the queue
+const READY = _Task.READY = 0x10; // The state to use when the task is able to be run
+const IN_PROGRESS = _Task.IN_PROGRESS = 0x30; // The state to use when the task is currently running
+const FINISHED = _Task.FINISHED = 0x50; // The state to use when the task has completed running successfully
+const CANCELED = _Task.CANCELED = 0xCA; // The state to use when the task has to be removed before its completion
+const ERROR = _Task.ERROR = 0xFF; // The state to use when the task must stop early due to an unexpected issue
+
+export { _Task };

--- a/lib/js/src/manager/_Task.js
+++ b/lib/js/src/manager/_Task.js
@@ -41,6 +41,7 @@ import { _uuid } from '../util/_uuid.js';
 class _Task {
     /**
      * Initializes an instance of _Task.
+     * @param {String} name - The name value for this task.
      * @class
      */
     constructor (name = null) {

--- a/lib/js/src/manager/screen/_SoftButtonManagerBase.js
+++ b/lib/js/src/manager/screen/_SoftButtonManagerBase.js
@@ -31,6 +31,7 @@
 */
 
 import { _SubManagerBase } from '../_SubManagerBase.js';
+import { _Task } from '../_Task.js';
 import { FunctionID } from '../../rpc/enums/FunctionID.js';
 import { ButtonName } from '../../rpc/enums/ButtonName.js';
 import { SoftButton } from '../../rpc/structs/SoftButton.js';
@@ -285,7 +286,9 @@ class _SoftButtonManagerBase extends _SubManagerBase {
             if (this._batchingUpdates) {
                 resolve(false);
             }
-            this._addTask(this._updateTask(resolve));
+            const task = new _Task();
+            task.onExecute = this._updateTask(resolve);
+            this._addTask(task);
         });
     }
 

--- a/lib/js/src/manager/screen/_TextAndGraphicManagerBase.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicManagerBase.js
@@ -31,6 +31,7 @@
 */
 
 import { _SubManagerBase } from '../_SubManagerBase.js';
+import { _Task } from '../_Task.js';
 import { Show } from '../../rpc/messages/Show.js';
 import { MetadataTags } from '../../rpc/structs/MetadataTags.js';
 import { ImageFieldName } from '../../rpc/enums/ImageFieldName.js';
@@ -116,7 +117,9 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
             if (this._batchingUpdates) {
                 resolve(false);
             }
-            this._addTask(this._sdlUpdate(resolve));
+            const task = new _Task();
+            task.onExecute = this._sdlUpdate(resolve);
+            this._addTask(task);
         });
     }
 

--- a/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
+++ b/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
@@ -31,6 +31,7 @@
 */
 
 import { _SubManagerBase } from '../_SubManagerBase.js';
+import { _Task } from '../_Task.js';
 import { FunctionID } from '../../rpc/enums/FunctionID.js';
 import { DeleteCommand } from '../../rpc/messages/DeleteCommand.js';
 import { AddCommand } from '../../rpc/messages/AddCommand.js';
@@ -85,7 +86,11 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
             return;
         }
         // add the commands to a queue to be processed later
-        this._addTask(this._update(voiceCommands));
+        // remove all other tasks except this one
+        this._cancelAllTasks();
+        const task = new _Task();
+        task.onExecute = this._update(voiceCommands);
+        this._addTask(task);
     }
 
     /**
@@ -95,13 +100,7 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
      * @param {VoiceCommand[]} voiceCommands - An array of VoiceCommand instances.
      */
     _update (voiceCommands) {
-        return async (taskQueue) => {
-            // only run the LAST task in the queue. remove all other tasks except the last one and return
-            if (taskQueue.length > 0) {
-                taskQueue.splice(0, taskQueue.length - 1);
-                return;
-            }
-
+        return async (task) => {
             this._lastVoiceCommandId = this._voiceCommandIdMin;
             for (const voiceCommand of voiceCommands) {
                 this._lastVoiceCommandId++;

--- a/tests/Test.js
+++ b/tests/Test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 
-const SDL = require('./../lib/js/dist/SDL.min.js');
+const SDL = require('./config.js').node;
 
 const SdlMsgVersion = SDL.rpc.structs.SdlMsgVersion;
 const TTSChunk = SDL.rpc.structs.TTSChunk;

--- a/tests/Validator.js
+++ b/tests/Validator.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const SDL = require('./../lib/js/dist/SDL.min.js');
+const SDL = require('./config.js').node;
 
 const RpcResponse = SDL.rpc.RpcResponse;
 const RpcRequest = SDL.rpc.RpcRequest;

--- a/tests/browser/bson.html
+++ b/tests/browser/bson.html
@@ -1,7 +1,7 @@
 <html>
 
 <head>
-    <script src='./../../lib/js/dist/SDL.min.js'></script>
+    <script src='./../../dist/js/SDL.min.js'></script>
 
     <script>
         function test(Bson) {
@@ -11,7 +11,7 @@
             let deserial = Bson.deserialize(serial)
             console.log(deserial);
         }
-        test(SDL.util.Bson);
+        test(SDL.util._Bson);
     </script>
 </head>
 

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,0 +1,4 @@
+// this is in case we change the location of the node dist file. it will be easy to update for all files
+module.exports = {
+    node: require('./../dist/node/SDL.min.js'),
+};

--- a/tests/managers/AppClient.js
+++ b/tests/managers/AppClient.js
@@ -29,8 +29,7 @@
 * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 * POSSIBILITY OF SUCH DAMAGE.
 */
-
-const SDL = require('../../lib/node/dist/SDL.min.js');
+const SDL = require('../config.js').node;
 const CONFIG = require('./config.js');
 
 class AppClient {

--- a/tests/managers/QueueTests.js
+++ b/tests/managers/QueueTests.js
@@ -1,0 +1,146 @@
+const SDL = require('../config.js').node;
+
+const Validator = require('../Validator');
+
+module.exports = function (appClient) {
+    const queueTester = new SDL.manager._SubManagerBase(appClient._sdlManager._lifecycleManager);
+    queueTester._handleTaskQueue();
+
+    describe('QueueTests', function () {
+        it('testQueueGetAndCancelTasks', async function () {
+            // add three tasks and inspect the queue state
+            const task1 = new SDL.manager._Task().setName('alpha');
+            const task2 = new SDL.manager._Task().setName('beta');
+            const task3 = new SDL.manager._Task().setName('gamma');
+
+            queueTester._addTask(task1);
+            queueTester._addTask(task2);
+            queueTester._addTask(task3);
+
+            const taskList = queueTester._getTasks();
+
+            Validator.assertEquals('alpha', taskList[0].getName());
+            Validator.assertEquals('beta', taskList[1].getName());
+            Validator.assertEquals('gamma', taskList[2].getName());
+
+            queueTester._cancelAllTasks('beta');
+
+            Validator.assertEquals('alpha', taskList[0].getName());
+            Validator.assertEquals('beta', taskList[1].getName());
+            Validator.assertEquals('gamma', taskList[2].getName());
+            Validator.assertEquals(SDL.manager._Task.READY, taskList[0].getState());
+            Validator.assertEquals(SDL.manager._Task.CANCELED, taskList[1].getState());
+            Validator.assertEquals(SDL.manager._Task.READY, taskList[2].getState());
+
+            queueTester._cancelAllTasks();
+
+            Validator.assertEquals('alpha', taskList[0].getName());
+            Validator.assertEquals('beta', taskList[1].getName());
+            Validator.assertEquals('gamma', taskList[2].getName());
+            Validator.assertEquals(SDL.manager._Task.CANCELED, taskList[0].getState());
+            Validator.assertEquals(SDL.manager._Task.CANCELED, taskList[1].getState());
+            Validator.assertEquals(SDL.manager._Task.CANCELED, taskList[2].getState());
+
+            // flush the task queue and enable task running
+            queueTester._canRunTasks = true;
+
+            await queueTester._invokeTaskQueue();
+            Validator.assertEquals(0, taskList.length);
+        });
+
+        it('testQueuePriority', async function () {
+            queueTester._canRunTasks = false;
+
+            // add three tasks and inspect the queue state
+            const task1 = new SDL.manager._Task().setName('alpha').setPriority(1);
+            const task2 = new SDL.manager._Task().setName('beta').setPriority(-1);
+            const task3 = new SDL.manager._Task().setName('gamma').setPriority(2);
+            const task4 = new SDL.manager._Task().setName('delta').setPriority(1);
+
+            queueTester._addTask(task1);
+            queueTester._addTask(task2);
+            queueTester._addTask(task3);
+            queueTester._addTask(task4);
+
+            const taskList = queueTester._getTasks();
+
+            Validator.assertEquals('gamma', taskList[0].getName());
+            Validator.assertEquals('alpha', taskList[1].getName());
+            Validator.assertEquals('delta', taskList[2].getName());
+            Validator.assertEquals('beta', taskList[3].getName());
+
+            // flush the task queue and enable task running
+            queueTester._cancelAllTasks();
+            queueTester._canRunTasks = true;
+
+            await queueTester._invokeTaskQueue();
+        });
+
+        it('testQueueBlocking', async function () {
+            queueTester._canRunTasks = false;
+
+            const task1 = new SDL.manager._Task().setName('alpha');
+            const task2 = new SDL.manager._Task().setName('beta');
+            const task3 = new SDL.manager._Task().setName('gamma');
+            task1.onExecute = () => {};
+            task2.onExecute = () => {};
+            task3.onExecute = () => {};
+            task2.switchStates(SDL.manager._Task.BLOCKED);
+
+            queueTester._addTask(task1);
+            queueTester._addTask(task2);
+            queueTester._addTask(task3);
+
+            queueTester._canRunTasks = true;
+            await queueTester._invokeTaskQueue();
+
+            // the second task should block the queue from running
+            const taskList = queueTester._getTasks();
+            Validator.assertEquals('beta', taskList[0].getName());
+            Validator.assertEquals('gamma', taskList[1].getName());
+
+            task2.switchStates(SDL.manager._Task.READY);
+            await queueTester._invokeTaskQueue();
+            Validator.assertEquals(0, taskList.length);
+        });
+
+        it('testQueueConcurrency', async function () {
+            queueTester._canRunTasks = false;
+            let taskCompleted = false;
+            const sleep = async () => {
+                await new Promise(res => setTimeout(res, 200));
+            };
+            const callbackFunc = (oldState, newState) => {
+                if (newState === SDL.manager._Task.FINISHED) {
+                    taskCompleted = true;
+                }
+            };
+            const task1 = new SDL.manager._Task().setName('alpha')
+                .setIsConcurrent(true)
+                .setCallback(callbackFunc);
+            const task2 = new SDL.manager._Task().setName('beta')
+                .setIsConcurrent(true)
+                .setCallback(callbackFunc);
+            const task3 = new SDL.manager._Task().setName('gamma')
+                .setIsConcurrent(true)
+                .setCallback(callbackFunc);
+            task1.onExecute = sleep;
+            task2.onExecute = sleep;
+            task3.onExecute = sleep;
+
+            queueTester._addTask(task1);
+            queueTester._addTask(task2);
+            queueTester._addTask(task3);
+
+            queueTester._canRunTasks = true;
+            await queueTester._invokeTaskQueue();
+
+            // this next section should execute immediately, as we are not waiting for the tasks to complete
+            Validator.assertEquals(false, taskCompleted);
+
+            // clean up
+            queueTester._cancelAllTasks();
+            await queueTester._invokeTaskQueue();
+        });
+    });
+};

--- a/tests/managers/TaskTests.js
+++ b/tests/managers/TaskTests.js
@@ -1,0 +1,67 @@
+const expect = require('chai').expect;
+const SDL = require('../config.js').node;
+
+const Validator = require('../Validator');
+
+module.exports = function (appClient) {
+    describe('TaskTests', function () {
+        it('testTaskGetterSetter', function (done) {
+            const callback = () => {};
+            // test getter/setters
+            const tester = new SDL.manager._Task('sweet');
+            tester.setCallback(callback)
+                .setIsConcurrent(true)
+                .setPriority(7);
+
+            Validator.assertEquals('sweet', tester.getName());
+            Validator.assertEquals(callback, tester.getCallback());
+            Validator.assertEquals(true, tester.getIsConcurrent());
+            Validator.assertEquals(7, tester.getPriority());
+
+            tester.setName('sour');
+
+            Validator.assertEquals('sour', tester.getName());
+
+            Validator.assertEquals(SDL.manager._Task.READY, tester.getState());
+            expect(tester.getId()).to.exist;
+
+            done();
+        });
+
+        it('testTaskSwitchStates', function (done) {
+            let callbackCalled = false;
+
+            const callback = (oldState, newState) => {
+                Validator.assertEquals(SDL.manager._Task.READY, oldState);
+                Validator.assertEquals(SDL.manager._Task.CANCELED, newState);
+                callbackCalled = true;
+            };
+
+            const tester = new SDL.manager._Task();
+            tester.setCallback(callback);
+            tester.switchStates(SDL.manager._Task.CANCELED);
+
+            Validator.assertEquals(true, callbackCalled);
+
+            done();
+        });
+
+        it('testTaskRunner', function (done) {
+            let executeCalled = false;
+
+            const tester = new SDL.manager._Task();
+            tester.onExecute = (task) => {
+                // task should be in progress when running
+                executeCalled = true;
+                Validator.assertEquals(SDL.manager._Task.IN_PROGRESS, task.getState());
+            };
+            tester.run()
+                .then(() => {
+                    // task should be finished once the async function ends
+                    Validator.assertEquals(SDL.manager._Task.FINISHED, tester.getState());
+                    Validator.assertEquals(true, executeCalled);
+                    done();
+                });
+        });
+    });
+};

--- a/tests/managers/file/FileManagerTests.js
+++ b/tests/managers/file/FileManagerTests.js
@@ -1,7 +1,7 @@
 const chai = require('chai');
 const expect = chai.expect;
 chai.use(require('chai-as-promised'));
-const SDL = require('./../../../lib/node/dist/SDL.min.js');
+const SDL = require('../../config.js').node;
 
 // Mocking framework
 // Used to stub an RPC call so that it isn't actually sent to Core

--- a/tests/managers/index.js
+++ b/tests/managers/index.js
@@ -5,6 +5,8 @@ const softButtonManagerTests = require('./screen/SoftButtonManagerTests');
 const screenManagerTests = require('./screen/ScreenManagerTests');
 const lifecycleManagerTests = require('./lifecycle/LifecycleManagerTests');
 const fileManagerTests = require('./file/FileManagerTests');
+const taskTests = require('./TaskTests');
+const queueTests = require('./QueueTests');
 
 // connect to core and select the app on the HMI to run the tests
 describe('ManagerTests', function () {
@@ -19,6 +21,8 @@ describe('ManagerTests', function () {
                 screenManagerTests(appClient);
                 lifecycleManagerTests(appClient);
                 fileManagerTests(appClient);
+                taskTests(appClient);
+                queueTests(appClient);
                 setTimeout(function () {
                     teardown();
                     done();

--- a/tests/managers/lifecycle/LifecycleManagerTests.js
+++ b/tests/managers/lifecycle/LifecycleManagerTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../config.js').node;
 
 // Mocking framework used so that some RPCs are not actually sent to Core, but the response mimicked
 const sinon = require('sinon');

--- a/tests/managers/permission/PermissionManagerTests.js
+++ b/tests/managers/permission/PermissionManagerTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../config.js').node;
 
 const Validator = require('./../../Validator');
 module.exports = function (appClient) {

--- a/tests/managers/screen/ScreenManagerTests.js
+++ b/tests/managers/screen/ScreenManagerTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../lib/node/dist/SDL.min.js');
+const SDL = require('../../config.js').node;
 
 const Validator = require('../../Validator');
 

--- a/tests/managers/screen/SoftButtonManagerTests.js
+++ b/tests/managers/screen/SoftButtonManagerTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../config.js').node;
 
 const Validator = require('../../Validator');
 

--- a/tests/node/protocol/BinaryFrameHeaderTests.js
+++ b/tests/node/protocol/BinaryFrameHeaderTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../config.js').node;
 
 const FunctionID = SDL.rpc.enums.FunctionID;
 const _BinaryFrameHeader = SDL.protocol._BinaryFrameHeader;

--- a/tests/node/rpc/enums/AmbientLightStatusTests.js
+++ b/tests/node/rpc/enums/AmbientLightStatusTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 
 const AmbientLightStatus = SDL.rpc.enums.AmbientLightStatus;
 const Validator = require('./../../../Validator.js');

--- a/tests/node/rpc/enums/AppHMITypeTests.js
+++ b/tests/node/rpc/enums/AppHMITypeTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 
 const AppHMIType = SDL.rpc.enums.AppHMIType;
 const Validator = require('./../../../Validator.js');

--- a/tests/node/rpc/enums/AppInterfaceUnregisteredReasonTests.js
+++ b/tests/node/rpc/enums/AppInterfaceUnregisteredReasonTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 
 const AppInterfaceUnregisteredReason = SDL.rpc.enums.AppInterfaceUnregisteredReason;
 const Validator = require('./../../../Validator.js');

--- a/tests/node/rpc/enums/CapacityUnitTests.js
+++ b/tests/node/rpc/enums/CapacityUnitTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 
 const CapacityUnit = SDL.rpc.enums.CapacityUnit;
 const Validator = require('./../../../Validator.js');

--- a/tests/node/rpc/enums/PRNDLTests.js
+++ b/tests/node/rpc/enums/PRNDLTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 
 const PRNDL = SDL.rpc.enums.PRNDL;
 const Validator = require('./../../../Validator.js');

--- a/tests/node/rpc/enums/PredefinedLayoutTests.js
+++ b/tests/node/rpc/enums/PredefinedLayoutTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 
 const PredefinedLayout = SDL.rpc.enums.PredefinedLayout;
 const Validator = require('./../../../Validator.js');

--- a/tests/node/rpc/enums/TransmissionTypeTests.js
+++ b/tests/node/rpc/enums/TransmissionTypeTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 
 const TransmissionType = SDL.rpc.enums.TransmissionType;
 const Validator = require('./../../../Validator.js');

--- a/tests/node/rpc/enums/VehicleDataTypeTests.js
+++ b/tests/node/rpc/enums/VehicleDataTypeTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 
 const VehicleDataType = SDL.rpc.enums.VehicleDataType;
 const Validator = require('./../../../Validator.js');

--- a/tests/node/rpc/messages/BaseRpcTests.js
+++ b/tests/node/rpc/messages/BaseRpcTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 
 const RpcRequest = SDL.rpc.RpcRequest;
 const RpcResponse = SDL.rpc.RpcResponse;

--- a/tests/node/rpc/messages/GetVehicleDataResponseTests.js
+++ b/tests/node/rpc/messages/GetVehicleDataResponseTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const GetVehicleDataResponse = SDL.rpc.messages.GetVehicleDataResponse;
 const FunctionID = SDL.rpc.enums.FunctionID;
 const MessageType = SDL.rpc.enums.MessageType;

--- a/tests/node/rpc/messages/GetVehicleDataTests.js
+++ b/tests/node/rpc/messages/GetVehicleDataTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const GetVehicleData = SDL.rpc.messages.GetVehicleData;
 const FunctionID = SDL.rpc.enums.FunctionID;
 const MessageType = SDL.rpc.enums.MessageType;

--- a/tests/node/rpc/messages/OnHmiStatusTests.js
+++ b/tests/node/rpc/messages/OnHmiStatusTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const OnHMIStatus = SDL.rpc.messages.OnHMIStatus;
 const FunctionID = SDL.rpc.enums.FunctionID;
 const MessageType = SDL.rpc.enums.MessageType;

--- a/tests/node/rpc/messages/OnSystemRequestTests.js
+++ b/tests/node/rpc/messages/OnSystemRequestTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const OnSystemRequest = SDL.rpc.messages.OnSystemRequest;
 const FunctionID = SDL.rpc.enums.FunctionID;
 const MessageType = SDL.rpc.enums.MessageType;

--- a/tests/node/rpc/messages/OnVehicleDataTests.js
+++ b/tests/node/rpc/messages/OnVehicleDataTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const OnVehicleData = SDL.rpc.messages.OnVehicleData;
 const FunctionID = SDL.rpc.enums.FunctionID;
 const MessageType = SDL.rpc.enums.MessageType;

--- a/tests/node/rpc/messages/RegisterAppInterfaceResponseTests.js
+++ b/tests/node/rpc/messages/RegisterAppInterfaceResponseTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const RegisterAppInterfaceResponse = SDL.rpc.messages.RegisterAppInterfaceResponse;
 const FunctionID = SDL.rpc.enums.FunctionID;
 const MessageType = SDL.rpc.enums.MessageType;

--- a/tests/node/rpc/messages/RegisterAppInterfaceTests.js
+++ b/tests/node/rpc/messages/RegisterAppInterfaceTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const RegisterAppInterface = SDL.rpc.messages.RegisterAppInterface;
 const FunctionID = SDL.rpc.enums.FunctionID;
 const MessageType = SDL.rpc.enums.MessageType;

--- a/tests/node/rpc/messages/RpcNotificationTests.js
+++ b/tests/node/rpc/messages/RpcNotificationTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const MessageType = SDL.rpc.enums.MessageType;
 const RpcNotification = SDL.rpc.RpcNotification;
 

--- a/tests/node/rpc/messages/RpcRequestTests.js
+++ b/tests/node/rpc/messages/RpcRequestTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const MessageType = SDL.rpc.enums.MessageType;
 const RpcRequest = SDL.rpc.RpcRequest;
 

--- a/tests/node/rpc/messages/RpcResponseTests.js
+++ b/tests/node/rpc/messages/RpcResponseTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const MessageType = SDL.rpc.enums.MessageType;
 const RpcResponse = SDL.rpc.RpcResponse;
 

--- a/tests/node/rpc/messages/SubscribeVehicleDataResponseTests.js
+++ b/tests/node/rpc/messages/SubscribeVehicleDataResponseTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const SubscribeVehicleDataResponse = SDL.rpc.messages.SubscribeVehicleDataResponse;
 const FunctionID = SDL.rpc.enums.FunctionID;
 const MessageType = SDL.rpc.enums.MessageType;

--- a/tests/node/rpc/messages/SubscribeVehicleDataTests.js
+++ b/tests/node/rpc/messages/SubscribeVehicleDataTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const SubscribeVehicleData = SDL.rpc.messages.SubscribeVehicleData;
 const FunctionID = SDL.rpc.enums.FunctionID;
 const MessageType = SDL.rpc.enums.MessageType;

--- a/tests/node/rpc/messages/UnsubscribeVehicleDataResponseTests.js
+++ b/tests/node/rpc/messages/UnsubscribeVehicleDataResponseTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const UnsubscribeVehicleDataResponse = SDL.rpc.messages.UnsubscribeVehicleDataResponse;
 const FunctionID = SDL.rpc.enums.FunctionID;
 const MessageType = SDL.rpc.enums.MessageType;

--- a/tests/node/rpc/messages/UnsubscribeVehicleDataTests.js
+++ b/tests/node/rpc/messages/UnsubscribeVehicleDataTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const UnsubscribeVehicleData = SDL.rpc.messages.UnsubscribeVehicleData;
 const FunctionID = SDL.rpc.enums.FunctionID;
 const MessageType = SDL.rpc.enums.MessageType;

--- a/tests/node/rpc/structs/FuelRangeTests.js
+++ b/tests/node/rpc/structs/FuelRangeTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const FuelRange = SDL.rpc.structs.FuelRange;
 
 const Test = require('./../../../Test.js');

--- a/tests/node/rpc/structs/GearStatusTests.js
+++ b/tests/node/rpc/structs/GearStatusTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const GearStatus = SDL.rpc.structs.GearStatus;
 const PRNDL = SDL.rpc.enums.PRNDL;
 const TransmissionType = SDL.rpc.enums.TransmissionType;

--- a/tests/node/rpc/structs/ImageTests.js
+++ b/tests/node/rpc/structs/ImageTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const Image = SDL.rpc.structs.Image;
 
 const Test = require('./../../../Test.js');

--- a/tests/node/rpc/structs/StabilityControlsStatusTests.js
+++ b/tests/node/rpc/structs/StabilityControlsStatusTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const StabilityControlsStatus = SDL.rpc.structs.StabilityControlsStatus;
 const VehicleDataStatus = SDL.rpc.enums.VehicleDataStatus;
 

--- a/tests/node/rpc/structs/WindowStateTests.js
+++ b/tests/node/rpc/structs/WindowStateTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const WindowState = SDL.rpc.structs.WindowState;
 
 const Validator = require('./../../../Validator.js');

--- a/tests/node/rpc/structs/WindowStatusTests.js
+++ b/tests/node/rpc/structs/WindowStatusTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 const WindowStatus = SDL.rpc.structs.WindowStatus;
 
 const Validator = require('./../../../Validator.js');

--- a/tests/node/streaming/video/VideoStreamingParametersTest.js
+++ b/tests/node/streaming/video/VideoStreamingParametersTest.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../../config.js').node;
 
 const Validator = require('./../../../Validator');
 

--- a/tests/node/transport/TransportTypeTests.js
+++ b/tests/node/transport/TransportTypeTests.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../config.js').node;
 
 const TransportType = SDL.transport.enums.TransportType;
 

--- a/tests/node/util/BitConverterTest.js
+++ b/tests/node/util/BitConverterTest.js
@@ -1,5 +1,5 @@
 
-const SDL = require('./../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../config.js').node;
 const BitConverter = SDL.util._BitConverter;
 const Validator = require('./../../Validator.js');
 

--- a/tests/node/util/BsonTest.js
+++ b/tests/node/util/BsonTest.js
@@ -1,4 +1,4 @@
-const SDL = require('./../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../config.js').node;
 const Bson = SDL.util._Bson;
 const Validator = require('./../../Validator.js');
 

--- a/tests/node/util/VersionTest.js
+++ b/tests/node/util/VersionTest.js
@@ -1,5 +1,5 @@
 
-const SDL = require('./../../../lib/js/dist/SDL.min.js');
+const SDL = require('../../config.js').node;
 const Validator = require('./../../Validator.js');
 
 const Version = SDL.util.Version;


### PR DESCRIPTION
This PR is **ready** for review.

Resolves #300 

### Risk
This PR makes **no** API changes.

### Summary
This PR updates the internal queuing capabilities that the SDL managers use to allocate their tasks. A new _Task class is created which offers flexibility in how tasks should be handled when being placed in the queue. Unit tests are created to showcase what can be done.

Additionally, since the build files' locations have moved, the existing tests are updated to point their build imports to the correct location.