### PR TITLE
[SDL 0279] Screen Manager Subscribe Buttons

### DIFF
--- a/examples/js/hello-sdl/index.html
+++ b/examples/js/hello-sdl/index.html
@@ -131,6 +131,17 @@
 
                 // wait for the FULL state for more functionality
                 if (hmiLevel === SDL.rpc.enums.HMILevel.HMI_FULL) {
+                    // add button listeners
+                    const screenManager = this._sdlManager.getScreenManager();
+                    const ButtonName = SDL.rpc.enums.ButtonName;
+                    const buttonNames = [ButtonName.PLAY_PAUSE, ButtonName.SEEKLEFT, ButtonName.SEEKRIGHT, ButtonName.AC_MAX, ButtonName.AC, ButtonName.RECIRCULATE,
+                        ButtonName.FAN_UP, ButtonName.FAN_DOWN, ButtonName.TEMP_UP, ButtonName.TEMP_DOWN, ButtonName.FAN_DOWN, ButtonName.DEFROST_MAX, ButtonName.DEFROST_REAR, ButtonName.DEFROST,
+                        ButtonName.UPPER_VENT, ButtonName.LOWER_VENT, ButtonName.VOLUME_UP, ButtonName.VOLUME_DOWN, ButtonName.EJECT, ButtonName.SOURCE, ButtonName.SHUFFLE, ButtonName.REPEAT];
+
+                    for (const buttonName of buttonNames) {
+                        await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this));
+                    }
+
                     const art1 = new SDL.manager.file.filetypes.SdlArtwork('logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)
                         .setFilePath(this._filePath);
 
@@ -153,7 +164,6 @@
                     ];
 
                     // set the softbuttons now and rotate through the states of the first softbutton
-                    const screenManager = this._sdlManager.getScreenManager();
                     await screenManager.setSoftButtonObjects(softButtonObjects);
 
                     await this._sleep(2000);
@@ -185,6 +195,14 @@
                 return new Promise((resolve) => {
                     setTimeout(resolve, timeout);
                 });
+            }
+
+            _onButtonListener (buttonName, onButton) {
+                if (onButton instanceof SDL.rpc.messages.OnButtonPress) {
+                    this._sdlManager.getScreenManager().setTextField1(`${buttonName} pressed`);
+                } else if (onButton instanceof SDL.rpc.messages.OnButtonEvent) {
+                    this._sdlManager.getScreenManager().setTextField2(`${buttonName} ${onButton.getButtonEventMode()}`);
+                }
             }
 
             _logPermissions () {

--- a/examples/node/hello-sdl-tcp/index.js
+++ b/examples/node/hello-sdl-tcp/index.js
@@ -132,8 +132,8 @@ class AppClient {
                 ButtonName.FAN_UP, ButtonName.FAN_DOWN, ButtonName.TEMP_UP, ButtonName.TEMP_DOWN, ButtonName.FAN_DOWN, ButtonName.DEFROST_MAX, ButtonName.DEFROST_REAR, ButtonName.DEFROST,
                 ButtonName.UPPER_VENT, ButtonName.LOWER_VENT, ButtonName.VOLUME_UP, ButtonName.VOLUME_DOWN, ButtonName.EJECT, ButtonName.SOURCE, ButtonName.SHUFFLE, ButtonName.REPEAT];
 
-            for (const buttonName in buttonNames) {
-                screenManager.addButtonListener(buttonName, this._onButtonListener);
+            for (let buttonName of buttonNames) {
+                await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this));
             }
 
             const art1 = new SDL.manager.file.filetypes.SdlArtwork('logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)
@@ -185,11 +185,11 @@ class AppClient {
         }
     }
 
-    _onButtonListener (onButton) {
+    _onButtonListener (buttonName, onButton) {
         if (onButton instanceof SDL.rpc.messages.OnButtonPress) {
-            this._sdlManager.getScreenManager().setTextField1(`${onButton.getButtonName()} pressed`);
+            this._sdlManager.getScreenManager().setTextField1(`${buttonName} pressed`);
         } else if (onButton instanceof SDL.rpc.messages.OnButtonEvent) {
-            this._sdlManager.getScreenManager().setTextField2(`${onButton.getButtonName()} ${onButton.getButtonEventMode()}`);
+            this._sdlManager.getScreenManager().setTextField2(`${buttonName} ${onButton.getButtonEventMode()}`);
         }
     }
 

--- a/examples/node/hello-sdl-tcp/index.js
+++ b/examples/node/hello-sdl-tcp/index.js
@@ -126,6 +126,16 @@ class AppClient {
 
         // wait for the FULL state for more functionality
         if (hmiLevel === SDL.rpc.enums.HMILevel.HMI_FULL) {
+            const screenManager = this._sdlManager.getScreenManager();
+            const ButtonName = SDL.rpc.enums.ButtonName;
+            const buttonNames = [ButtonName.PLAY_PAUSE, ButtonName.SEEKLEFT, ButtonName.SEEKRIGHT, ButtonName.AC_MAX, ButtonName.AC, ButtonName.RECIRCULATE,
+                ButtonName.FAN_UP, ButtonName.FAN_DOWN, ButtonName.TEMP_UP, ButtonName.TEMP_DOWN, ButtonName.FAN_DOWN, ButtonName.DEFROST_MAX, ButtonName.DEFROST_REAR, ButtonName.DEFROST,
+                ButtonName.UPPER_VENT, ButtonName.LOWER_VENT, ButtonName.VOLUME_UP, ButtonName.VOLUME_DOWN, ButtonName.EJECT, ButtonName.SOURCE, ButtonName.SHUFFLE, ButtonName.REPEAT];
+
+            for (const buttonName in buttonNames) {
+                screenManager.addButtonListener(buttonName, this._onButtonListener);
+            }
+
             const art1 = new SDL.manager.file.filetypes.SdlArtwork('logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)
                 .setFilePath(this._filePath);
 
@@ -148,7 +158,6 @@ class AppClient {
             ];
 
             // set the softbuttons now and rotate through the states of the first softbutton
-            const screenManager = this._sdlManager.getScreenManager();
             await screenManager.setSoftButtonObjects(softButtonObjects);
 
             await this._sleep(2000);
@@ -173,6 +182,14 @@ class AppClient {
             await this._sdlManager.sendRpcResolve(new SDL.rpc.messages.UnregisterAppInterface());
 
             this._sdlManager.dispose();
+        }
+    }
+
+    _onButtonListener (onButton) {
+        if (onButton instanceof SDL.rpc.messages.OnButtonPress) {
+            this._sdlManager.getScreenManager().setTextField1(`${onButton.getButtonName()} pressed`);
+        } else if (onButton instanceof SDL.rpc.messages.OnButtonEvent) {
+            this._sdlManager.getScreenManager().setTextField2(`${onButton.getButtonName()} ${onButton.getButtonEventMode()}`);
         }
     }
 

--- a/examples/node/hello-sdl-tcp/index.js
+++ b/examples/node/hello-sdl-tcp/index.js
@@ -126,13 +126,14 @@ class AppClient {
 
         // wait for the FULL state for more functionality
         if (hmiLevel === SDL.rpc.enums.HMILevel.HMI_FULL) {
+            // add button listeners
             const screenManager = this._sdlManager.getScreenManager();
             const ButtonName = SDL.rpc.enums.ButtonName;
             const buttonNames = [ButtonName.PLAY_PAUSE, ButtonName.SEEKLEFT, ButtonName.SEEKRIGHT, ButtonName.AC_MAX, ButtonName.AC, ButtonName.RECIRCULATE,
                 ButtonName.FAN_UP, ButtonName.FAN_DOWN, ButtonName.TEMP_UP, ButtonName.TEMP_DOWN, ButtonName.FAN_DOWN, ButtonName.DEFROST_MAX, ButtonName.DEFROST_REAR, ButtonName.DEFROST,
                 ButtonName.UPPER_VENT, ButtonName.LOWER_VENT, ButtonName.VOLUME_UP, ButtonName.VOLUME_DOWN, ButtonName.EJECT, ButtonName.SOURCE, ButtonName.SHUFFLE, ButtonName.REPEAT];
 
-            for (let buttonName of buttonNames) {
+            for (const buttonName of buttonNames) {
                 await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this));
             }
 

--- a/examples/node/hello-sdl-tcp/index.js
+++ b/examples/node/hello-sdl-tcp/index.js
@@ -129,12 +129,14 @@ class AppClient {
             // add button listeners
             const screenManager = this._sdlManager.getScreenManager();
             const ButtonName = SDL.rpc.enums.ButtonName;
-            const buttonNames = [ButtonName.PLAY_PAUSE, ButtonName.SEEKLEFT, ButtonName.SEEKRIGHT, ButtonName.AC_MAX, ButtonName.AC, ButtonName.RECIRCULATE,
-                ButtonName.FAN_UP, ButtonName.FAN_DOWN, ButtonName.TEMP_UP, ButtonName.TEMP_DOWN, ButtonName.FAN_DOWN, ButtonName.DEFROST_MAX, ButtonName.DEFROST_REAR, ButtonName.DEFROST,
-                ButtonName.UPPER_VENT, ButtonName.LOWER_VENT, ButtonName.VOLUME_UP, ButtonName.VOLUME_DOWN, ButtonName.EJECT, ButtonName.SOURCE, ButtonName.SHUFFLE, ButtonName.REPEAT];
+            const buttonNames = [ButtonName.AC_MAX, ButtonName.AC, ButtonName.RECIRCULATE, ButtonName.FAN_UP, ButtonName.FAN_DOWN, ButtonName.TEMP_UP, 
+                ButtonName.TEMP_DOWN, ButtonName.FAN_DOWN, ButtonName.DEFROST_MAX, ButtonName.DEFROST_REAR, ButtonName.DEFROST, ButtonName.UPPER_VENT,
+                ButtonName.LOWER_VENT, ButtonName.VOLUME_UP, ButtonName.VOLUME_DOWN, ButtonName.EJECT, ButtonName.SOURCE, ButtonName.SHUFFLE, ButtonName.REPEAT];
 
             for (const buttonName of buttonNames) {
-                await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this));
+                await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this)).catch(function (err) {
+                    console.error(err);
+                });
             }
 
             const art1 = new SDL.manager.file.filetypes.SdlArtwork('logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)

--- a/examples/node/hello-sdl/AppClient.js
+++ b/examples/node/hello-sdl/AppClient.js
@@ -122,8 +122,18 @@ class AppClient {
 
     async _checkReadyState () {
         if (this._managersReady && this._hmiFull) {
-            // add voice commands
+            // add button listeners
             const screenManager = this._sdlManager.getScreenManager();
+            const ButtonName = SDL.rpc.enums.ButtonName;
+            const buttonNames = [ButtonName.PLAY_PAUSE, ButtonName.SEEKLEFT, ButtonName.SEEKRIGHT, ButtonName.AC_MAX, ButtonName.AC, ButtonName.RECIRCULATE,
+                ButtonName.FAN_UP, ButtonName.FAN_DOWN, ButtonName.TEMP_UP, ButtonName.TEMP_DOWN, ButtonName.FAN_DOWN, ButtonName.DEFROST_MAX, ButtonName.DEFROST_REAR, ButtonName.DEFROST,
+                ButtonName.UPPER_VENT, ButtonName.LOWER_VENT, ButtonName.VOLUME_UP, ButtonName.VOLUME_DOWN, ButtonName.EJECT, ButtonName.SOURCE, ButtonName.SHUFFLE, ButtonName.REPEAT];
+
+            for (const buttonName of buttonNames) {
+                await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this));
+            }
+
+            // add voice commands
             screenManager.setVoiceCommands([
                 new SDL.manager.screen.utils.VoiceCommand(['Option 1'], () => {
                     console.log('Option one selected!');
@@ -181,6 +191,14 @@ class AppClient {
         return new Promise((resolve) => {
             setTimeout(resolve, timeout);
         });
+    }
+
+    _onButtonListener (buttonName, onButton) {
+        if (onButton instanceof SDL.rpc.messages.OnButtonPress) {
+            this._sdlManager.getScreenManager().setTextField1(`${buttonName} pressed`);
+        } else if (onButton instanceof SDL.rpc.messages.OnButtonEvent) {
+            this._sdlManager.getScreenManager().setTextField2(`${buttonName} ${onButton.getButtonEventMode()}`);
+        }
     }
 
     _logPermissions () {

--- a/examples/node/hello-sdl/index.js
+++ b/examples/node/hello-sdl/index.js
@@ -30,8 +30,6 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-const fs = require('fs');
-const SDL = require('./SDL.min.js');
 const CONFIG = require('./config.js');
 const WS = require('ws');
 const AppClient = require('./AppClient.js');

--- a/examples/webengine/hello-sdl/index.html
+++ b/examples/webengine/hello-sdl/index.html
@@ -162,6 +162,17 @@
 
                 // wait for the FULL state for more functionality
                 if (hmiLevel === SDL.rpc.enums.HMILevel.HMI_FULL) {
+                    // add button listeners
+                    const screenManager = this._sdlManager.getScreenManager();
+                    const ButtonName = SDL.rpc.enums.ButtonName;
+                    const buttonNames = [ButtonName.PLAY_PAUSE, ButtonName.SEEKLEFT, ButtonName.SEEKRIGHT, ButtonName.AC_MAX, ButtonName.AC, ButtonName.RECIRCULATE,
+                        ButtonName.FAN_UP, ButtonName.FAN_DOWN, ButtonName.TEMP_UP, ButtonName.TEMP_DOWN, ButtonName.FAN_DOWN, ButtonName.DEFROST_MAX, ButtonName.DEFROST_REAR, ButtonName.DEFROST,
+                        ButtonName.UPPER_VENT, ButtonName.LOWER_VENT, ButtonName.VOLUME_UP, ButtonName.VOLUME_DOWN, ButtonName.EJECT, ButtonName.SOURCE, ButtonName.SHUFFLE, ButtonName.REPEAT];
+
+                    for (const buttonName of buttonNames) {
+                        await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this));
+                    }
+
                     if (!this._isTemplateSwitchCommandAdded && this._permissionManager && this._permissionManager.isRpcAllowed(SDL.rpc.enums.FunctionID.AddCommand)) {
                         this._logRegularMessage('Adding return to WEB_VIEW template command');
                         this._isTemplateSwitchCommandAdded = true;
@@ -200,6 +211,14 @@
                 return new Promise((resolve) => {
                     setTimeout(resolve, timeout);
                 });
+            }
+
+            _onButtonListener (buttonName, onButton) {
+                if (onButton instanceof SDL.rpc.messages.OnButtonPress) {
+                    this._sdlManager.getScreenManager().setTextField1(`${buttonName} pressed`);
+                } else if (onButton instanceof SDL.rpc.messages.OnButtonEvent) {
+                    this._sdlManager.getScreenManager().setTextField2(`${buttonName} ${onButton.getButtonEventMode()}`);
+                }
             }
 
             async sendRpcRequest(request) {

--- a/lib/js/src/manager/screen/_ScreenManagerBase.js
+++ b/lib/js/src/manager/screen/_ScreenManagerBase.js
@@ -400,12 +400,12 @@ class _ScreenManagerBase extends _SubManagerBase {
         return success1 && success2;
     }
 
-    addButtonListener (buttonName, listener) {
-        this._subscribeButtonManager.addButtonListener(buttonName, listener);
+    async addButtonListener (buttonName, listener) {
+        return await this._subscribeButtonManager._addButtonListener(buttonName, listener);
     }
 
-    removeButtonListener (buttonName, listener) {
-        this._subscribeButtonManager.removeButtonListener(buttonName, listener);
+    async removeButtonListener (buttonName, listener) {
+        return await this._subscribeButtonManager._removeButtonListener(buttonName, listener);
     }
 }
 

--- a/lib/js/src/manager/screen/_ScreenManagerBase.js
+++ b/lib/js/src/manager/screen/_ScreenManagerBase.js
@@ -34,6 +34,7 @@ import { _SubManagerBase } from '../_SubManagerBase.js';
 import { _SoftButtonManager } from './_SoftButtonManager.js';
 import { _TextAndGraphicManager } from './_TextAndGraphicManager.js';
 import { _VoiceCommandManager } from './_VoiceCommandManager.js';
+import { _SubscribeButtonManager } from './_SubscribeButtonManager';
 
 class _ScreenManagerBase extends _SubManagerBase {
     /**
@@ -52,6 +53,7 @@ class _ScreenManagerBase extends _SubManagerBase {
             this._textAndGraphicManager = new _TextAndGraphicManager(lifecycleManager, this._fileManager, this._softButtonManager);
         }
         this._voiceCommandManager = new _VoiceCommandManager(lifecycleManager);
+        this._subscribeButtonManager = new _SubscribeButtonManager(lifecycleManager);
     }
 
     /**
@@ -63,6 +65,7 @@ class _ScreenManagerBase extends _SubManagerBase {
             this._softButtonManager.start(),
             this._textAndGraphicManager.start(),
             this._voiceCommandManager.start(),
+            this._subscribeButtonManager.start(),
         ]);
         this._transitionToState(_SubManagerBase.READY);
         await super.start();
@@ -75,6 +78,7 @@ class _ScreenManagerBase extends _SubManagerBase {
         this._softButtonManager.dispose();
         this._textAndGraphicManager.dispose();
         this._voiceCommandManager.dispose();
+        this._subscribeButtonManager.dispose();
         super.dispose();
     }
 
@@ -394,6 +398,14 @@ class _ScreenManagerBase extends _SubManagerBase {
         const success2 = await this._textAndGraphicManager.update();
 
         return success1 && success2;
+    }
+
+    addButtonListener (buttonName, listener) {
+        this._subscribeButtonManager.addButtonListener(buttonName, listener);
+    }
+
+    removeButtonListener (buttonName, listener) {
+        this._subscribeButtonManager.removeButtonListener(buttonName, listener);
     }
 }
 

--- a/lib/js/src/manager/screen/_ScreenManagerBase.js
+++ b/lib/js/src/manager/screen/_ScreenManagerBase.js
@@ -400,12 +400,12 @@ class _ScreenManagerBase extends _SubManagerBase {
         return success1 && success2;
     }
 
-    async addButtonListener (buttonName, listener) {
-        return await this._subscribeButtonManager._addButtonListener(buttonName, listener);
+    addButtonListener (buttonName, listener) {
+        return this._subscribeButtonManager._addButtonListener(buttonName, listener);
     }
 
-    async removeButtonListener (buttonName, listener) {
-        return await this._subscribeButtonManager._removeButtonListener(buttonName, listener);
+    removeButtonListener (buttonName, listener) {
+        return this._subscribeButtonManager._removeButtonListener(buttonName, listener);
     }
 }
 

--- a/lib/js/src/manager/screen/_ScreenManagerBase.js
+++ b/lib/js/src/manager/screen/_ScreenManagerBase.js
@@ -400,12 +400,26 @@ class _ScreenManagerBase extends _SubManagerBase {
         return success1 && success2;
     }
 
-    addButtonListener (buttonName, listener) {
-        return this._subscribeButtonManager._addButtonListener(buttonName, listener);
+    /**
+     * Removes a listener from the list of listeners and unsubscribes to the button if it was the last listener.
+     * @param {ButtonName} buttonName - Name of the button
+     * @param {Function} listener - The listener to be removed
+     * @returns {Promise} - returns _ScreenManagerBase when finished
+     */
+    async addButtonListener (buttonName, listener) {
+        await this._subscribeButtonManager._addButtonListener(buttonName, listener);
+        return this;
     }
 
-    removeButtonListener (buttonName, listener) {
-        return this._subscribeButtonManager._removeButtonListener(buttonName, listener);
+    /**
+     * Removes a listener from the list of listeners and unsubscribes to the button if it was the last listener.
+     * @param {ButtonName} buttonName - Name of the button
+     * @param {Function} listener - The listener to be removed
+     * @returns {Promise} - returns _ScreenManagerBase when finished
+     */
+    async removeButtonListener (buttonName, listener) {
+        await this._subscribeButtonManager._removeButtonListener(buttonName, listener);
+        return this;
     }
 }
 

--- a/lib/js/src/manager/screen/_ScreenManagerBase.js
+++ b/lib/js/src/manager/screen/_ScreenManagerBase.js
@@ -401,7 +401,7 @@ class _ScreenManagerBase extends _SubManagerBase {
     }
 
     /**
-     * Removes a listener from the list of listeners and unsubscribes to the button if it was the last listener.
+     * Adds a listener to the list of listeners for a button and subscribes to the button if not already subscribed.
      * @param {ButtonName} buttonName - Name of the button
      * @param {Function} listener - The listener to be removed
      * @returns {Promise} - returns _ScreenManagerBase when finished

--- a/lib/js/src/manager/screen/_SubscribeButtonManager.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManager.js
@@ -30,7 +30,7 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-import { _SubscribeButtonManagerBase } from './_SubscibeButtonManagerBase';
+import { _SubscribeButtonManagerBase } from './_SubscribeButtonManagerBase';
 
 class _SubscribeButtonManager extends _SubscribeButtonManagerBase {
     /**

--- a/lib/js/src/manager/screen/_SubscribeButtonManager.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManager.js
@@ -1,0 +1,47 @@
+/*
+* Copyright (c) 2020, Livio, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following
+* disclaimer in the documentation and/or other materials provided with the
+* distribution.
+*
+* Neither the name of the Livio Inc. nor the names of its contributors
+* may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import { _SubscribeButtonManagerBase } from './_SubscibeButtonManagerBase';
+
+class _SubscribeButtonManager extends _SubscribeButtonManagerBase {
+    /**
+     * Initializes an instance of _SubscribeButtonManager.
+     * @class
+     * @param {_LifecycleManager} lifecycleManager - An instance of _LifecycleManager.
+     * @param {FileManager} fileManager - An instance of FileManager.
+     */
+    constructor (lifecycleManager, fileManager) {
+        super(lifecycleManager, fileManager);
+    }
+}
+
+export { _SubscribeButtonManager };

--- a/lib/js/src/manager/screen/_SubscribeButtonManager.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManager.js
@@ -37,10 +37,9 @@ class _SubscribeButtonManager extends _SubscribeButtonManagerBase {
      * Initializes an instance of _SubscribeButtonManager.
      * @class
      * @param {_LifecycleManager} lifecycleManager - An instance of _LifecycleManager.
-     * @param {FileManager} fileManager - An instance of FileManager.
      */
-    constructor (lifecycleManager, fileManager) {
-        super(lifecycleManager, fileManager);
+    constructor (lifecycleManager) {
+        super(lifecycleManager);
     }
 }
 

--- a/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
@@ -114,7 +114,7 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
             return;
         }
 
-        if (listenerArray.size() > 1) {
+        if (listenerArray.length > 1) {
             this._onButtonListeners.set(buttonName, _ArrayTools.arrayRemove(listenerArray, listener));
             return;
         }

--- a/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
@@ -11,8 +11,6 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
         super(lifecycleManager);
         this.setRpcNotificationListeners();
         this._onButtonListeners = new Map();
-        this._onButtonPressListener = null;
-        this._onButtonEventListener = null;
     }
 
     async start () {
@@ -23,7 +21,7 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
     dispose () {
         super.dispose();
         if (this._onButtonListeners !== null) {
-            this._onButtonListeners.splice(0, this._onButtonListeners.length);
+            this._onButtonListeners.clear();
         }
         this._lifecycleManager.removeRpcListener(FunctionID.OnButtonPress, this._onButtonPressListener);
         this._lifecycleManager.removeRpcListener(FunctionID.onButtonEvent, this._onButtonEventListener);
@@ -32,80 +30,94 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
     async _addButtonListener (buttonName, listener) {
         if (listener === null || listener === undefined || buttonName === null || buttonName === undefined) {
             // error, look into how the other managers handle this
-            return;
+            return this;
         }
 
-        if (this._onButtonListeners[buttonName] === null || this._onButtonListeners[buttonName] === undefined) {
+        //if (this._onButtonListeners.get(buttonName) === null || this._onButtonListeners.get(buttonName) === undefined) {
             await this._subscribeButtonRequest(buttonName, listener);
-        }
+        //}
+        return this;
     }
 
     async _removeButtonListener (buttonName, listener) {
         if (listener === null || listener === undefined || buttonName === null || buttonName === undefined) {
             // error, look into how the other managers handle this
-            return;
+            return this;
         }
 
-        if (this._onButtonListeners[buttonName] === null || this._onButtonListeners === undefined || !this._onButtonListeners[buttonName].includes(listener)) {
-            return;
+        if (this._onButtonListeners.get(buttonName) === null || this._onButtonListeners === undefined || !this._onButtonListeners.get(buttonName).includes(listener)) {
+            return this;
         }
         await this._unsubscribeButtonRequest(buttonName, listener);
+        return this;
     }
 
     async _subscribeButtonRequest (buttonName, listener) {
-        const subscribeButton = new SubscribeButton();
+        const subscribeButton = new SubscribeButton().setButtonName(buttonName);
         const response = await this._lifecycleManager.sendRpcResolve(subscribeButton);
+
         if (response.getSuccess()) {
+            console.log('subscribed to ', buttonName);
             let listenerArray = this._onButtonListeners.get(buttonName);
             // If no array exists yet for this function id, create one
             if (!Array.isArray(listenerArray)) {
                 listenerArray = [];
             }
             listenerArray.push(listener);
-            this._onButtonListener.set(buttonName, listenerArray);
-            return;
+            this._onButtonListeners.set(buttonName, listenerArray);
         }
+        return this;
         // error
     }
 
     async _unsubscribeButtonRequest (buttonName, listener) {
-        const unsubscribeButton = new UnsubscribeButton();
+        const unsubscribeButton = new UnsubscribeButton().setButtonName(buttonName);
         const response = await this._lifecycleManager.sendRpcResolve(unsubscribeButton);
         if (response.getSuccess()) {
             const listenerArray = this._onButtonListeners.get(buttonName);
             if (Array.isArray(listenerArray)) {
                 this._onButtonListeners.set(buttonName, _ArrayTools.arrayRemove(listenerArray, listener));
             }
-            return;
         }
+        return this;
         // error
-    }
-
-    _onButtonPressListener (onButtonPress) {
-        if (onButtonPress instanceof OnButtonPress) {
-            const listeners = this._onButtonListener.get(onButtonPress.getButtonName());
-            if (listeners !== null && listeners !== undefined && listeners.length > 0) {
-                for (const listener in listeners) {
-                    listener(onButtonPress.getButtonName(), onButtonPress);
-                }
-            }
-        }
     }
 
     _onButtonEventListener (onButtonEvent) {
         if (onButtonEvent instanceof OnButtonEvent) {
-            const listeners = this._onButtonListener.get(onButtonEvent.getButtonName());
+            console.log(this);
+            const listeners = this._onButtonListeners.get(onButtonEvent.getButtonName());
             if (listeners !== null && listeners !== undefined && listeners.length > 0) {
-                for (const listener in listeners) {
+                for (const listener of listeners) {
                     listener(onButtonEvent.getButtonName(), onButtonEvent);
                 }
             }
         }
+        return this;
+    }
+
+    getButtonListeners () {
+        return this._onButtonListeners;
     }
 
     setRpcNotificationListeners () {
-        this._lifecycleManager.addRpcListener(FunctionID.OnButtonPress, this._onButtonPressListener);
-        this._lifecycleManager.addRpcListener(FunctionID.OnButtonEvent, this._onButtonEventListener);
+
+        const _onButtonPressListener = function (onButtonPress) {
+            if (onButtonPress instanceof OnButtonPress) {
+                console.log(getButtonListeners().size);
+                const listeners = this._onButtonListeners.get(onButtonPress.getButtonName());
+                if (listeners !== null && listeners !== undefined && listeners.length > 0) {
+                    for (const listener of listeners) {
+                        listener(onButtonPress.getButtonName(), onButtonPress);
+                    }
+                }
+            }
+            return this;
+        }
+
+        this._lifecycleManager.addRpcListener(FunctionID.OnButtonPress, _onButtonPressListener);
+        //this._lifecycleManager.addRpcListener(FunctionID.OnButtonEvent, this._onButtonEventListener);
+        return this;
     }
 }
 

--- a/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
@@ -33,21 +33,32 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
             return this;
         }
 
-        //if (this._onButtonListeners.get(buttonName) === null || this._onButtonListeners.get(buttonName) === undefined) {
+        if (this._onButtonListeners.get(buttonName) === null || this._onButtonListeners.get(buttonName) === undefined) {
             await this._subscribeButtonRequest(buttonName, listener);
-        //}
+            return;
+        }
+
+        if (this._onButtonListeners.get(buttonName).includes(listener)) {
+            // Already subscribed to buttonName
+            return;
+        }
+
+        this._onButtonListeners.get(buttonName).push(listener);
         return this;
     }
 
     async _removeButtonListener (buttonName, listener) {
-        console.log(buttonName, listener, this._onButtonListeners.get(buttonName))
         if (listener === null || listener === undefined || buttonName === null || buttonName === undefined) {
             // error, look into how the other managers handle this
             return this;
         }
 
-        if (this._onButtonListeners === undefined || this._onButtonListeners.get(buttonName) === null) {
+        if (this._onButtonListeners.get(buttonName) === null || this._onButtonListeners.get(buttonName) === undefined || !this._onButtonListeners.get(buttonName).includes(listener)) {
             return this;
+        }
+
+        if (this._onButtonListeners.get(buttonName).size() > 1) {
+            // remove from array
         }
         await this._unsubscribeButtonRequest(buttonName, listener);
         return this;
@@ -93,7 +104,7 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
                 }
             }
             return this;
-        }
+        };
 
         const _onButtonEventListener = function (onButtonEvent) {
             if (onButtonEvent instanceof OnButtonEvent) {
@@ -105,7 +116,7 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
                 }
             }
             return this;
-        }
+        };
 
         this._lifecycleManager.addRpcListener(FunctionID.OnButtonPress, _onButtonPressListener.bind(this));
         this._lifecycleManager.addRpcListener(FunctionID.OnButtonEvent, _onButtonEventListener.bind(this));

--- a/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
@@ -4,12 +4,13 @@ import { UnsubscribeButton } from '../../rpc/messages/UnsubscribeButton';
 import { OnButtonPress } from '../../rpc/messages/OnButtonPress';
 import { OnButtonEvent } from '../../rpc/messages/OnButtonEvent';
 import { FunctionID } from '../../rpc/enums/FunctionID';
+import { _ArrayTools } from '../../util/_ArrayTools';
 
 class _SubscribeButtonManagerBase extends _SubManagerBase {
     constructor (lifecycleManager) {
         super(lifecycleManager);
         this.setRpcNotificationListeners();
-        this._onButtonListeners = {};
+        this._onButtonListeners = new Map();
         this._onButtonPressListener = null;
         this._onButtonEventListener = null;
     }
@@ -22,7 +23,7 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
     dispose () {
         super.dispose();
         if (this._onButtonListeners !== null) {
-            this._onButtonListeners = null;
+            this._onButtonListeners.splice(0, this._onButtonListeners.length);
         }
         this._lifecycleManager.removeRpcListener(FunctionID.OnButtonPress, this._onButtonPressListener);
         this._lifecycleManager.removeRpcListener(FunctionID.onButtonEvent, this._onButtonEventListener);
@@ -52,20 +53,23 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
     }
 
     async _subscribeButtonRequest (buttonName, listener) {
-        const subscribeButton = new SubscribeButton().setRpcNotificationListeners(listener);
+        const subscribeButton = new SubscribeButton();
         const response = await this._lifecycleManager.sendRpcResolve(subscribeButton);
         if (response.getSuccess()) {
-            this._onButtonListeners[buttonName] = listener;
+            this._onButtonListeners[buttonName].push(listener);
             return;
         }
         // error
     }
 
     async _unsubscribeButtonRequest (buttonName, listener) {
-        const unsubscribeButton = new UnsubscribeButton().setRpcNotificationListeners(listener);
+        const unsubscribeButton = new UnsubscribeButton();
         const response = await this._lifecycleManager.sendRpcResolve(unsubscribeButton);
         if (response.getSuccess()) {
-            // this._onButtonListeners[buttonName] = listener;
+            const listenerArray = this._onButtonListeners.get(buttonName);
+            if (Array.isArray(listenerArray)) {
+                this._onButtonListeners.set(buttonName, _ArrayTools.arrayRemove(listenerArray, listener));
+            }
             return;
         }
         // error

--- a/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
@@ -5,7 +5,7 @@ import { OnButtonPress } from '../../rpc/messages/OnButtonPress';
 import { OnButtonEvent } from '../../rpc/messages/OnButtonEvent';
 import { FunctionID } from '../../rpc/enums/FunctionID';
 
-class _SubscribeButtonMangerBase extends _SubManagerBase {
+class _SubscribeButtonManagerBase extends _SubManagerBase {
     constructor (lifecycleManager) {
         super(lifecycleManager);
         this.setRpcNotificationListeners();
@@ -98,4 +98,4 @@ class _SubscribeButtonMangerBase extends _SubManagerBase {
     }
 }
 
-export { _SubscribeButtonMangerBase };
+export { _SubscribeButtonManagerBase };

--- a/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
@@ -1,0 +1,101 @@
+import _SubManagerBase from '../_SubManagerBase.js';
+import SubscribeButton from '../../rpc/messages/SubscribeButton';
+import UnsubscribeButton from '../../rpc/messages/UnsubscribeButton';
+import OnButtonPress from '../../rpc/messages/OnButtonPress';
+import OnButtonEvent from '../../rpc/messages/OnButtonEvent';
+import FunctionID from '../../rpc/enums/FunctionID';
+
+class _SubscribeButtonMangerBase extends _SubManagerBase {
+    constructor (lifecycleManager) {
+        super(lifecycleManager);
+        this.setRpcNotificationListeners();
+        this._onButtonListeners = {};
+        this._onButtonPressListener = null;
+        this._onButtonEventListener = null;
+    }
+
+    async start () {
+        this._transitionToState(_SubManagerBase.READY);
+        await super.start();
+    }
+
+    dispose () {
+        super.dispose();
+        if (this._onButtonListeners !== null) {
+            this._onButtonListeners = null;
+        }
+        this._lifecycleManager.removeRpcListener(FunctionID.OnButtonPress, this._onButtonPressListener);
+        this._lifecycleManager.removeRpcListener(FunctionID.onButtonEvent, this._onButtonEventListener);
+    }
+
+    _addButtonListener (buttonName, listener) {
+        if (listener === null || listener === undefined || buttonName === null || buttonName === undefined) {
+            // error, look into how the other managers handle this
+            return;
+        }
+
+        if (this._onButtonListeners[buttonName] === null || this._onButtonListeners[buttonName] === undefined) {
+            this._subscribeButtonRequest(buttonName, listener);
+        }
+    }
+
+    _removeButtonListener (buttonName, listener) {
+        if (listener === null || listener === undefined || buttonName === null || buttonName === undefined) {
+            // error, look into how the other managers handle this            
+            return;
+        }
+
+        if (this._onButtonListeners[buttonName] === null || this._onButtonListeners === undefined || !this._onButtonListeners[buttonName].includes(listener)) {
+            return;
+        }
+        this._unsubscribeButtonRequest(buttonName, listener);
+    }
+
+    async _subscribeButtonRequest (buttonName, listener) {
+        const subscribeButton = new SubscribeButton().setRpcNotificationListeners(listener);
+        const response = await this._lifecycleManager.sendRpcResolve(subscribeButton);
+        if (response.getSuccess()) {
+            this._onButtonListeners[buttonName] = listener;
+            return;
+        }
+        // error
+    }
+
+    async _unsubscribeButtonRequest (buttonName, listener) {
+        const unsubscribeButton = new UnsubscribeButton().setRpcNotificationListeners(listener);
+        const response = await this._lifecycleManager.sendRpcResolve(unsubscribeButton);
+        if (response.getSuccess()) {
+            // this._onButtonListeners[buttonName] = listener;
+            return;
+        }
+        // error
+    }
+
+    setRpcNotificationListeners () {
+        this._onButtonPressListener = function (onButtonPress) {
+            if (onButtonPress instanceof OnButtonPress) {
+                const listeners = this._onButtonListener[onButtonPress.getButtonName()];
+                if (listeners !== null && listeners !== undefined && listeners.length > 0) {
+                    for (const listener in listeners) {
+                        listener(onButtonPress.getButtonName(), onButtonPress);
+                    }
+                }
+            }
+        };
+        this._lifecycleManager.addRpcListener(FunctionID.OnButtonPress, this._onButtonPressListener);
+
+        this._onButtonEventListener = function (onButtonEvent) {
+            if (onButtonEvent instanceof OnButtonEvent) {
+                const listeners = this._onButtonListener[onButtonEvent.getButtonName()];
+                if (listeners !== null && listeners !== undefined && listeners.length > 0) {
+                    for (const listener in listeners) {
+                        listener(onButtonEvent.getButtonName(), onButtonEvent);
+                    }
+                }
+            }
+        };
+        this._lifecycleManager.addRpcListener(FunctionID.OnButtonEvent, this._onButtonEventListener);
+    }
+}
+
+export { _SubscribeButtonMangerBase };

--- a/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
@@ -1,9 +1,9 @@
-import _SubManagerBase from '../_SubManagerBase.js';
-import SubscribeButton from '../../rpc/messages/SubscribeButton';
-import UnsubscribeButton from '../../rpc/messages/UnsubscribeButton';
-import OnButtonPress from '../../rpc/messages/OnButtonPress';
-import OnButtonEvent from '../../rpc/messages/OnButtonEvent';
-import FunctionID from '../../rpc/enums/FunctionID';
+import { _SubManagerBase } from '../_SubManagerBase.js';
+import { SubscribeButton } from '../../rpc/messages/SubscribeButton';
+import { UnsubscribeButton } from '../../rpc/messages/UnsubscribeButton';
+import { OnButtonPress } from '../../rpc/messages/OnButtonPress';
+import { OnButtonEvent } from '../../rpc/messages/OnButtonEvent';
+import { FunctionID } from '../../rpc/enums/FunctionID';
 
 class _SubscribeButtonMangerBase extends _SubManagerBase {
     constructor (lifecycleManager) {

--- a/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
@@ -9,7 +9,7 @@ import { _ArrayTools } from '../../util/_ArrayTools';
 class _SubscribeButtonManagerBase extends _SubManagerBase {
     constructor (lifecycleManager) {
         super(lifecycleManager);
-        this.setRpcNotificationListeners();
+        this._setRpcNotificationListeners();
         this._onButtonListeners = new Map();
     }
 
@@ -40,12 +40,13 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
     }
 
     async _removeButtonListener (buttonName, listener) {
+        console.log(buttonName, listener, this._onButtonListeners.get(buttonName))
         if (listener === null || listener === undefined || buttonName === null || buttonName === undefined) {
             // error, look into how the other managers handle this
             return this;
         }
 
-        if (this._onButtonListeners.get(buttonName) === null || this._onButtonListeners === undefined || !this._onButtonListeners.get(buttonName).includes(listener)) {
+        if (this._onButtonListeners === undefined || this._onButtonListeners.get(buttonName) === null) {
             return this;
         }
         await this._unsubscribeButtonRequest(buttonName, listener);
@@ -55,9 +56,7 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
     async _subscribeButtonRequest (buttonName, listener) {
         const subscribeButton = new SubscribeButton().setButtonName(buttonName);
         const response = await this._lifecycleManager.sendRpcResolve(subscribeButton);
-
         if (response.getSuccess()) {
-            console.log('subscribed to ', buttonName);
             let listenerArray = this._onButtonListeners.get(buttonName);
             // If no array exists yet for this function id, create one
             if (!Array.isArray(listenerArray)) {
@@ -83,28 +82,9 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
         // error
     }
 
-    _onButtonEventListener (onButtonEvent) {
-        if (onButtonEvent instanceof OnButtonEvent) {
-            console.log(this);
-            const listeners = this._onButtonListeners.get(onButtonEvent.getButtonName());
-            if (listeners !== null && listeners !== undefined && listeners.length > 0) {
-                for (const listener of listeners) {
-                    listener(onButtonEvent.getButtonName(), onButtonEvent);
-                }
-            }
-        }
-        return this;
-    }
-
-    getButtonListeners () {
-        return this._onButtonListeners;
-    }
-
-    setRpcNotificationListeners () {
-
+    _setRpcNotificationListeners () {
         const _onButtonPressListener = function (onButtonPress) {
             if (onButtonPress instanceof OnButtonPress) {
-                console.log(getButtonListeners().size);
                 const listeners = this._onButtonListeners.get(onButtonPress.getButtonName());
                 if (listeners !== null && listeners !== undefined && listeners.length > 0) {
                     for (const listener of listeners) {
@@ -115,8 +95,20 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
             return this;
         }
 
-        this._lifecycleManager.addRpcListener(FunctionID.OnButtonPress, _onButtonPressListener);
-        //this._lifecycleManager.addRpcListener(FunctionID.OnButtonEvent, this._onButtonEventListener);
+        const _onButtonEventListener = function (onButtonEvent) {
+            if (onButtonEvent instanceof OnButtonEvent) {
+                const listeners = this._onButtonListeners.get(onButtonEvent.getButtonName());
+                if (listeners !== null && listeners !== undefined && listeners.length > 0) {
+                    for (const listener of listeners) {
+                        listener(onButtonEvent.getButtonName(), onButtonEvent);
+                    }
+                }
+            }
+            return this;
+        }
+
+        this._lifecycleManager.addRpcListener(FunctionID.OnButtonPress, _onButtonPressListener.bind(this));
+        this._lifecycleManager.addRpcListener(FunctionID.OnButtonEvent, _onButtonEventListener.bind(this));
         return this;
     }
 }

--- a/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
@@ -1,3 +1,35 @@
+/*
+* Copyright (c) 2020, Livio, Inc.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* Redistributions of source code must retain the above copyright notice, this
+* list of conditions and the following disclaimer.
+*
+* Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following
+* disclaimer in the documentation and/or other materials provided with the
+* distribution.
+*
+* Neither the name of the Livio Inc. nor the names of its contributors
+* may be used to endorse or promote products derived from this software
+* without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
 import { _SubManagerBase } from '../_SubManagerBase.js';
 import { SubscribeButton } from '../../rpc/messages/SubscribeButton';
 import { UnsubscribeButton } from '../../rpc/messages/UnsubscribeButton';
@@ -7,29 +39,47 @@ import { FunctionID } from '../../rpc/enums/FunctionID';
 import { _ArrayTools } from '../../util/_ArrayTools';
 
 class _SubscribeButtonManagerBase extends _SubManagerBase {
+    /**
+     * Initializes an instance of _SubscribeButtonManager.
+     * @class
+     * @private
+     * @param {_LifecycleManager} lifecycleManager - An instance of _LifecycleManager.
+     */
     constructor (lifecycleManager) {
         super(lifecycleManager);
         this._setRpcNotificationListeners();
         this._onButtonListeners = new Map();
     }
 
+    /**
+     * After this method finishes, the manager is ready
+     * @returns {Promise} - A promise.
+     */
     async start () {
         this._transitionToState(_SubManagerBase.READY);
         await super.start();
     }
 
+    /**
+     * Teardown method
+     */
     dispose () {
         super.dispose();
         if (this._onButtonListeners !== null) {
             this._onButtonListeners.clear();
         }
         this._lifecycleManager.removeRpcListener(FunctionID.OnButtonPress, this._onButtonPressListener);
-        this._lifecycleManager.removeRpcListener(FunctionID.onButtonEvent, this._onButtonEventListener);
+        this._lifecycleManager.removeRpcListener(FunctionID.OnButtonEvent, this._onButtonEventListener);
     }
 
+    /**
+     * Adds a listener to the list of listeners for a button and subscribes to the button if not already subscribed.
+     * @param {ButtonName} buttonName - Name of the button
+     * @param {Function} listener - A function to invoke when a button notification occurs
+     */
     async _addButtonListener (buttonName, listener) {
         if (listener === null || listener === undefined || buttonName === null || buttonName === undefined) {
-            // error, look into how the other managers handle this
+            console.error('ButtonName and OnButtonListener cannot be null or undefined');
             return this;
         }
 
@@ -39,31 +89,42 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
         }
 
         if (this._onButtonListeners.get(buttonName).includes(listener)) {
-            // Already subscribed to buttonName
+            console.info(`Already subscribed to the button named ${buttonName}`);
             return;
         }
 
         this._onButtonListeners.get(buttonName).push(listener);
-        return this;
     }
 
+    /**
+     * Removes a listener from the list of listeners and unsubscribes to the button if it was the last listener.
+     * @param {ButtonName} buttonName - Name of the button
+     * @param {Function} listener - The listener to be removed
+     */
     async _removeButtonListener (buttonName, listener) {
         if (listener === null || listener === undefined || buttonName === null || buttonName === undefined) {
-            // error, look into how the other managers handle this
-            return this;
+            console.error('ButtonName and OnButtonListener cannot be null or undefined');
+            return;
         }
 
-        if (this._onButtonListeners.get(buttonName) === null || this._onButtonListeners.get(buttonName) === undefined || !this._onButtonListeners.get(buttonName).includes(listener)) {
-            return this;
+        const listenerArray = this._onButtonListeners.get(buttonName);
+        if (listenerArray === null || listenerArray === undefined || !listenerArray.includes(listener)) {
+            console.error(`Attempting to unsubscribe to the ${buttonName} button failed because it is not currently subscribed`);
+            return;
         }
 
         if (this._onButtonListeners.get(buttonName).size() > 1) {
-            // remove from array
+            this._onButtonListeners.set(buttonName, _ArrayTools.arrayRemove(listenerArray, listener));
+            return;
         }
         await this._unsubscribeButtonRequest(buttonName, listener);
-        return this;
     }
 
+    /**
+     * Sends a SubscribeButton RPC and adds a listener to the list of listeners
+     * @param {ButtonName} buttonName - Name of the button
+     * @param {Function} listener - A function to invoke when a button notification occurs
+     */
     async _subscribeButtonRequest (buttonName, listener) {
         const subscribeButton = new SubscribeButton().setButtonName(buttonName);
         const response = await this._lifecycleManager.sendRpcResolve(subscribeButton);
@@ -76,10 +137,13 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
             listenerArray.push(listener);
             this._onButtonListeners.set(buttonName, listenerArray);
         }
-        return this;
-        // error
     }
 
+    /**
+     * Sends an UnsubscribeButton RPC and removes a listener from the list of listeners
+     * @param {*} buttonName - Name of the button
+     * @param {*} listener - The listener to be removed
+     */
     async _unsubscribeButtonRequest (buttonName, listener) {
         const unsubscribeButton = new UnsubscribeButton().setButtonName(buttonName);
         const response = await this._lifecycleManager.sendRpcResolve(unsubscribeButton);
@@ -89,10 +153,11 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
                 this._onButtonListeners.set(buttonName, _ArrayTools.arrayRemove(listenerArray, listener));
             }
         }
-        return this;
-        // error
     }
 
+    /**
+     * Adds RPC listeners for OnButtonPress and OnButtonEvent that will call any listeners for those buttons
+     */
     _setRpcNotificationListeners () {
         const _onButtonPressListener = function (onButtonPress) {
             if (onButtonPress instanceof OnButtonPress) {
@@ -103,7 +168,6 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
                     }
                 }
             }
-            return this;
         };
 
         const _onButtonEventListener = function (onButtonEvent) {
@@ -115,12 +179,10 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
                     }
                 }
             }
-            return this;
         };
 
         this._lifecycleManager.addRpcListener(FunctionID.OnButtonPress, _onButtonPressListener.bind(this));
         this._lifecycleManager.addRpcListener(FunctionID.OnButtonEvent, _onButtonEventListener.bind(this));
-        return this;
     }
 }
 

--- a/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
@@ -42,7 +42,7 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
 
     _removeButtonListener (buttonName, listener) {
         if (listener === null || listener === undefined || buttonName === null || buttonName === undefined) {
-            // error, look into how the other managers handle this            
+            // error, look into how the other managers handle this
             return;
         }
 
@@ -56,7 +56,13 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
         const subscribeButton = new SubscribeButton();
         const response = await this._lifecycleManager.sendRpcResolve(subscribeButton);
         if (response.getSuccess()) {
-            this._onButtonListeners[buttonName].push(listener);
+            let listenerArray = this._onButtonListeners.get(buttonName);
+            // If no array exists yet for this function id, create one
+            if (!Array.isArray(listenerArray)) {
+                listenerArray = [];
+            }
+            listenerArray.push(listener);
+            this._onButtonListener.set(buttonName, listenerArray);
             return;
         }
         // error
@@ -78,7 +84,7 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
     setRpcNotificationListeners () {
         this._onButtonPressListener = function (onButtonPress) {
             if (onButtonPress instanceof OnButtonPress) {
-                const listeners = this._onButtonListener[onButtonPress.getButtonName()];
+                const listeners = this._onButtonListener.get(onButtonPress.getButtonName());
                 if (listeners !== null && listeners !== undefined && listeners.length > 0) {
                     for (const listener in listeners) {
                         listener(onButtonPress.getButtonName(), onButtonPress);
@@ -90,7 +96,7 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
 
         this._onButtonEventListener = function (onButtonEvent) {
             if (onButtonEvent instanceof OnButtonEvent) {
-                const listeners = this._onButtonListener[onButtonEvent.getButtonName()];
+                const listeners = this._onButtonListener.get(onButtonEvent.getButtonName());
                 if (listeners !== null && listeners !== undefined && listeners.length > 0) {
                     for (const listener in listeners) {
                         listener(onButtonEvent.getButtonName(), onButtonEvent);

--- a/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
@@ -29,18 +29,18 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
         this._lifecycleManager.removeRpcListener(FunctionID.onButtonEvent, this._onButtonEventListener);
     }
 
-    _addButtonListener (buttonName, listener) {
+    async _addButtonListener (buttonName, listener) {
         if (listener === null || listener === undefined || buttonName === null || buttonName === undefined) {
             // error, look into how the other managers handle this
             return;
         }
 
         if (this._onButtonListeners[buttonName] === null || this._onButtonListeners[buttonName] === undefined) {
-            this._subscribeButtonRequest(buttonName, listener);
+            await this._subscribeButtonRequest(buttonName, listener);
         }
     }
 
-    _removeButtonListener (buttonName, listener) {
+    async _removeButtonListener (buttonName, listener) {
         if (listener === null || listener === undefined || buttonName === null || buttonName === undefined) {
             // error, look into how the other managers handle this
             return;
@@ -49,7 +49,7 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
         if (this._onButtonListeners[buttonName] === null || this._onButtonListeners === undefined || !this._onButtonListeners[buttonName].includes(listener)) {
             return;
         }
-        this._unsubscribeButtonRequest(buttonName, listener);
+        await this._unsubscribeButtonRequest(buttonName, listener);
     }
 
     async _subscribeButtonRequest (buttonName, listener) {
@@ -81,29 +81,30 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
         // error
     }
 
-    setRpcNotificationListeners () {
-        this._onButtonPressListener = function (onButtonPress) {
-            if (onButtonPress instanceof OnButtonPress) {
-                const listeners = this._onButtonListener.get(onButtonPress.getButtonName());
-                if (listeners !== null && listeners !== undefined && listeners.length > 0) {
-                    for (const listener in listeners) {
-                        listener(onButtonPress.getButtonName(), onButtonPress);
-                    }
+    _onButtonPressListener (onButtonPress) {
+        if (onButtonPress instanceof OnButtonPress) {
+            const listeners = this._onButtonListener.get(onButtonPress.getButtonName());
+            if (listeners !== null && listeners !== undefined && listeners.length > 0) {
+                for (const listener in listeners) {
+                    listener(onButtonPress.getButtonName(), onButtonPress);
                 }
             }
-        };
-        this._lifecycleManager.addRpcListener(FunctionID.OnButtonPress, this._onButtonPressListener);
+        }
+    }
 
-        this._onButtonEventListener = function (onButtonEvent) {
-            if (onButtonEvent instanceof OnButtonEvent) {
-                const listeners = this._onButtonListener.get(onButtonEvent.getButtonName());
-                if (listeners !== null && listeners !== undefined && listeners.length > 0) {
-                    for (const listener in listeners) {
-                        listener(onButtonEvent.getButtonName(), onButtonEvent);
-                    }
+    _onButtonEventListener (onButtonEvent) {
+        if (onButtonEvent instanceof OnButtonEvent) {
+            const listeners = this._onButtonListener.get(onButtonEvent.getButtonName());
+            if (listeners !== null && listeners !== undefined && listeners.length > 0) {
+                for (const listener in listeners) {
+                    listener(onButtonEvent.getButtonName(), onButtonEvent);
                 }
             }
-        };
+        }
+    }
+
+    setRpcNotificationListeners () {
+        this._lifecycleManager.addRpcListener(FunctionID.OnButtonPress, this._onButtonPressListener);
         this._lifecycleManager.addRpcListener(FunctionID.OnButtonEvent, this._onButtonEventListener);
     }
 }

--- a/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
+++ b/lib/js/src/manager/screen/_SubscribeButtonManagerBase.js
@@ -80,15 +80,16 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
     async _addButtonListener (buttonName, listener) {
         if (listener === null || listener === undefined || buttonName === null || buttonName === undefined) {
             console.error('ButtonName and OnButtonListener cannot be null or undefined');
-            return this;
+            return;
         }
 
-        if (this._onButtonListeners.get(buttonName) === null || this._onButtonListeners.get(buttonName) === undefined) {
+        const listenerArray = this._onButtonListeners.get(buttonName);
+        if (listenerArray === null || listenerArray === undefined) {
             await this._subscribeButtonRequest(buttonName, listener);
             return;
         }
 
-        if (this._onButtonListeners.get(buttonName).includes(listener)) {
+        if (listenerArray.includes(listener)) {
             console.info(`Already subscribed to the button named ${buttonName}`);
             return;
         }
@@ -113,7 +114,7 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
             return;
         }
 
-        if (this._onButtonListeners.get(buttonName).size() > 1) {
+        if (listenerArray.size() > 1) {
             this._onButtonListeners.set(buttonName, _ArrayTools.arrayRemove(listenerArray, listener));
             return;
         }
@@ -136,13 +137,15 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
             }
             listenerArray.push(listener);
             this._onButtonListeners.set(buttonName, listenerArray);
+            return;
         }
+        throw new Error(`Attempt to subscribe to button named ${buttonName} failed. ResultCode: ${response.getResultCode()} info: ${response.getInfo()}`);
     }
 
     /**
      * Sends an UnsubscribeButton RPC and removes a listener from the list of listeners
-     * @param {*} buttonName - Name of the button
-     * @param {*} listener - The listener to be removed
+     * @param {ButtonName} buttonName - Name of the button
+     * @param {Function} listener - The listener to be removed
      */
     async _unsubscribeButtonRequest (buttonName, listener) {
         const unsubscribeButton = new UnsubscribeButton().setButtonName(buttonName);
@@ -152,7 +155,9 @@ class _SubscribeButtonManagerBase extends _SubManagerBase {
             if (Array.isArray(listenerArray)) {
                 this._onButtonListeners.set(buttonName, _ArrayTools.arrayRemove(listenerArray, listener));
             }
+            return;
         }
+        throw new Error(`Attempt to unsubscribe to button named ${buttonName} failed. ResultCode: ${response.getResultCode()} info: ${response.getInfo()}`);
     }
 
     /**


### PR DESCRIPTION
Fixes #118 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Run one of the example apps and press the AC button. The main text fields should portray a message saying the button was pressed.

### Summary
Includes the new SubscribeButtonManager and Base classes. These managers can be used to easily subscribe to OnButtonPress and OnButtonEvent notifications for specific buttons. This PR also updates the example apps to support the functionality of the new managers.