### PR TITLE
Add .values method for all enums

### DIFF
--- a/generator/templates/enum_template.js
+++ b/generator/templates/enum_template.js
@@ -71,6 +71,14 @@
     static keyForValue (value) {
         return {{name}}._keyForValue(value, {{name}}._MAP);
     }
+
+    /**
+     * Retrieve all enumerated values for this class
+     * @returns {*} - Returns an array of values
+     */
+    static values () {
+        return Object.values({{name}}._MAP);
+    }
 {% endblock %}
 {% block properties %}
 {{name}}._MAP = Object.freeze({

--- a/lib/js/src/manager/file/enums/StaticIconName.js
+++ b/lib/js/src/manager/file/enums/StaticIconName.js
@@ -1639,6 +1639,14 @@ class StaticIconName extends Enum {
     static keyForValue (value) {
         return StaticIconName._keyForValue(value, StaticIconName._MAP);
     }
+
+    /**
+     * Retrieve all enumerated values for this class
+     * @returns {*} - Returns an array of values
+     */
+    static values () {
+        return Object.values(StaticIconName._MAP);
+    }
 }
 
 StaticIconName._MAP = Object.freeze({

--- a/lib/js/src/manager/permission/enums/PermissionGroupStatus.js
+++ b/lib/js/src/manager/permission/enums/PermissionGroupStatus.js
@@ -95,6 +95,14 @@ class PermissionGroupStatus extends Enum {
     static keyForValue (value) {
         return PermissionGroupStatus._keyForValue(value, PermissionGroupStatus._MAP);
     }
+
+    /**
+     * Retrieve all enumerated values for this class
+     * @returns {*} - Returns an array of values
+     */
+    static values () {
+        return Object.values(PermissionGroupStatus._MAP);
+    }
 }
 
 PermissionGroupStatus._MAP = Object.freeze({

--- a/lib/js/src/manager/permission/enums/PermissionGroupType.js
+++ b/lib/js/src/manager/permission/enums/PermissionGroupType.js
@@ -79,6 +79,14 @@ class PermissionGroupType extends Enum {
     static keyForValue (value) {
         return PermissionGroupType._keyForValue(value, PermissionGroupType._MAP);
     }
+
+    /**
+     * Retrieve all enumerated values for this class
+     * @returns {*} - Returns an array of values
+     */
+    static values () {
+        return Object.values(PermissionGroupType._MAP);
+    }
 }
 
 PermissionGroupType._MAP = Object.freeze({

--- a/lib/js/src/protocol/enums/_FrameType.js
+++ b/lib/js/src/protocol/enums/_FrameType.js
@@ -94,6 +94,14 @@ class _FrameType extends Enum {
     static keyForValue (value) {
         return _FrameType._keyForValue(value, _FrameType._MAP);
     }
+
+    /**
+     * Retrieve all enumerated values for this class
+     * @returns {*} - Returns an array of values
+     */
+    static values () {
+        return Object.values(_FrameType._MAP);
+    }
 }
 
 _FrameType._MAP = Object.freeze({

--- a/lib/js/src/protocol/enums/_ServiceType.js
+++ b/lib/js/src/protocol/enums/_ServiceType.js
@@ -102,6 +102,14 @@ class _ServiceType extends Enum {
     static keyForValue (value) {
         return _ServiceType._keyForValue(value, _ServiceType._MAP);
     }
+
+    /**
+     * Retrieve all enumerated values for this class
+     * @returns {*} - Returns an array of values
+     */
+    static values () {
+        return Object.values(_ServiceType._MAP);
+    }
 }
 
 _ServiceType._MAP = Object.freeze({

--- a/lib/js/src/transport/enums/TransportType.js
+++ b/lib/js/src/transport/enums/TransportType.js
@@ -94,6 +94,14 @@ class TransportType extends Enum {
     static keyForValue (value) {
         return TransportType._keyForValue(value, TransportType._MAP);
     }
+
+    /**
+     * Retrieve all enumerated values for this class
+     * @returns {*} - Returns an array of values
+     */
+    static values () {
+        return Object.values(TransportType._MAP);
+    }
 }
 
 TransportType._MAP = Object.freeze({

--- a/lib/js/src/util/Enum.js
+++ b/lib/js/src/util/Enum.js
@@ -83,6 +83,15 @@ class Enum {
     valueForKey (key) {
         throw new Error('method must be overridden');
     }
+
+    /**
+     * A method for retrieving all values of an Enum-derived class
+     * @returns {*} - Returns an array of values
+     * @abstract
+     */
+    static values () {
+        throw new Error('method must be overridden');
+    }
 }
 
 export { Enum };


### PR DESCRIPTION
Fixes #312 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Summary
Adds a new method for all enums `.values()` to return a list of all values available for the enum