### PR TITLE
Fix request sending on permissions change

### DIFF
--- a/examples/js/hello-sdl/index.html
+++ b/examples/js/hello-sdl/index.html
@@ -98,6 +98,7 @@
 
                 this._sdlManager = new SDL.manager.SdlManager(this._appConfig, managerListener);
                 this._sdlManager.start();
+                this._isButtonSubscriptionRequested = false;
             }
 
             async _onConnected () {
@@ -131,15 +132,23 @@
 
                 // wait for the FULL state for more functionality
                 if (hmiLevel === SDL.rpc.enums.HMILevel.HMI_FULL) {
-                    // add button listeners
                     const screenManager = this._sdlManager.getScreenManager();
-                    const ButtonName = SDL.rpc.enums.ButtonName;
-                    const buttonNames = [ButtonName.AC_MAX, ButtonName.AC, ButtonName.RECIRCULATE, ButtonName.FAN_UP, ButtonName.FAN_DOWN, ButtonName.TEMP_UP,
-                        ButtonName.TEMP_DOWN, ButtonName.FAN_DOWN, ButtonName.DEFROST_MAX, ButtonName.DEFROST_REAR, ButtonName.DEFROST, ButtonName.UPPER_VENT,
-                        ButtonName.LOWER_VENT, ButtonName.VOLUME_UP, ButtonName.VOLUME_DOWN, ButtonName.EJECT, ButtonName.SOURCE, ButtonName.SHUFFLE, ButtonName.REPEAT];
+                    if (!this._isButtonSubscriptionRequested) {
+                        // add button listeners
+                        const ButtonName = SDL.rpc.enums.ButtonName;
+                        const buttonNames = [ButtonName.PRESET_0, ButtonName.PRESET_1, ButtonName.PRESET_2, ButtonName.PRESET_3,
+                                    ButtonName.PRESET_4, ButtonName.PRESET_5, ButtonName.PRESET_6, ButtonName.PRESET_7, ButtonName.PRESET_8,
+                                    ButtonName.PRESET_9, ButtonName.PLAY_PAUSE, ButtonName.OK, ButtonName.SEEKLEFT, ButtonName.SEEKRIGHT,
+                                    ButtonName.TUNEUP, ButtonName.TUNEDOWN];
 
-                    for (const buttonName of buttonNames) {
-                        await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this));
+                        for (const buttonName of buttonNames) {
+                            await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this))
+                                .catch((reason) => {
+                                    console.error(`Unable to subscribe to button: ${reason}`);
+                                });
+                        }
+
+                        this._isButtonSubscriptionRequested = true;
                     }
 
                     const art1 = new SDL.manager.file.filetypes.SdlArtwork('logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)

--- a/examples/node/hello-sdl-tcp/index.js
+++ b/examples/node/hello-sdl-tcp/index.js
@@ -93,6 +93,7 @@ class AppClient {
 
         this._sdlManager = new SDL.manager.SdlManager(this._appConfig, managerListener);
         this._sdlManager.start();
+        this._isButtonSubscriptionRequested = false;
     }
 
     async _onConnected () {
@@ -126,17 +127,22 @@ class AppClient {
 
         // wait for the FULL state for more functionality
         if (hmiLevel === SDL.rpc.enums.HMILevel.HMI_FULL) {
-            // add button listeners
             const screenManager = this._sdlManager.getScreenManager();
-            const ButtonName = SDL.rpc.enums.ButtonName;
-            const buttonNames = [ButtonName.AC_MAX, ButtonName.AC, ButtonName.RECIRCULATE, ButtonName.FAN_UP, ButtonName.FAN_DOWN, ButtonName.TEMP_UP,
-                ButtonName.TEMP_DOWN, ButtonName.FAN_DOWN, ButtonName.DEFROST_MAX, ButtonName.DEFROST_REAR, ButtonName.DEFROST, ButtonName.UPPER_VENT,
-                ButtonName.LOWER_VENT, ButtonName.VOLUME_UP, ButtonName.VOLUME_DOWN, ButtonName.EJECT, ButtonName.SOURCE, ButtonName.SHUFFLE, ButtonName.REPEAT];
+            if (!this._isButtonSubscriptionRequested) {
+                // add button listeners
+                const ButtonName = SDL.rpc.enums.ButtonName;
+                const buttonNames = [ButtonName.PRESET_0, ButtonName.PRESET_1, ButtonName.PRESET_2, ButtonName.PRESET_3,
+                    ButtonName.PRESET_4, ButtonName.PRESET_5, ButtonName.PRESET_6, ButtonName.PRESET_7, ButtonName.PRESET_8,
+                    ButtonName.PRESET_9, ButtonName.PLAY_PAUSE, ButtonName.OK, ButtonName.SEEKLEFT, ButtonName.SEEKRIGHT,
+                    ButtonName.TUNEUP, ButtonName.TUNEDOWN];
 
-            for (const buttonName of buttonNames) {
-                await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this)).catch(function (err) {
-                    console.error(err);
-                });
+                for (const buttonName of buttonNames) {
+                    await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this)).catch(function (err) {
+                        console.error(err);
+                    });
+                }
+
+                this._isButtonSubscriptionRequested = true;
             }
 
             const art1 = new SDL.manager.file.filetypes.SdlArtwork('logo', SDL.rpc.enums.FileType.GRAPHIC_PNG)

--- a/examples/node/hello-sdl/AppClient.js
+++ b/examples/node/hello-sdl/AppClient.js
@@ -102,6 +102,7 @@ class AppClient {
         // for a cloud server app the hmi full will be received before the managers report that they're ready!
         this._managersReady = false;
         this._hmiFull = false;
+        this._isButtonSubscriptionRequested = false;
     }
 
     _onConnected () {
@@ -122,15 +123,23 @@ class AppClient {
 
     async _checkReadyState () {
         if (this._managersReady && this._hmiFull) {
-            // add button listeners
             const screenManager = this._sdlManager.getScreenManager();
-            const ButtonName = SDL.rpc.enums.ButtonName;
-            const buttonNames = [ButtonName.AC_MAX, ButtonName.AC, ButtonName.RECIRCULATE, ButtonName.FAN_UP, ButtonName.FAN_DOWN, ButtonName.TEMP_UP,
-                ButtonName.TEMP_DOWN, ButtonName.FAN_DOWN, ButtonName.DEFROST_MAX, ButtonName.DEFROST_REAR, ButtonName.DEFROST, ButtonName.UPPER_VENT,
-                ButtonName.LOWER_VENT, ButtonName.VOLUME_UP, ButtonName.VOLUME_DOWN, ButtonName.EJECT, ButtonName.SOURCE, ButtonName.SHUFFLE, ButtonName.REPEAT];
+            if (!this._isButtonSubscriptionRequested) {
+                // add button listeners
+                const ButtonName = SDL.rpc.enums.ButtonName;
+                const buttonNames = [ButtonName.PRESET_0, ButtonName.PRESET_1, ButtonName.PRESET_2, ButtonName.PRESET_3,
+                    ButtonName.PRESET_4, ButtonName.PRESET_5, ButtonName.PRESET_6, ButtonName.PRESET_7, ButtonName.PRESET_8,
+                    ButtonName.PRESET_9, ButtonName.PLAY_PAUSE, ButtonName.OK, ButtonName.SEEKLEFT, ButtonName.SEEKRIGHT,
+                    ButtonName.TUNEUP, ButtonName.TUNEDOWN];
 
-            for (const buttonName of buttonNames) {
-                await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this));
+                for (const buttonName of buttonNames) {
+                    await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this))
+                        .catch((reason) => {
+                            console.error(`Unable to subscribe to button: ${reason}`);
+                        });
+                }
+
+                this._isButtonSubscriptionRequested = true;
             }
 
             // add voice commands

--- a/examples/webengine/hello-sdl/index.html
+++ b/examples/webengine/hello-sdl/index.html
@@ -93,6 +93,7 @@
 
                 this._currentTemplate = 'WEB_VIEW';
                 this._isTemplateSwitchCommandAdded = false;
+                this._isButtonSubscriptionRequested = false;
                 this._templateSwitchCommandId = 1001;
             }
 
@@ -162,18 +163,31 @@
 
                 // wait for the FULL state for more functionality
                 if (hmiLevel === SDL.rpc.enums.HMILevel.HMI_FULL) {
-                    // add button listeners
-                    const screenManager = this._sdlManager.getScreenManager();
-                    const ButtonName = SDL.rpc.enums.ButtonName;
-                    const buttonNames = [ButtonName.AC_MAX, ButtonName.AC, ButtonName.RECIRCULATE, ButtonName.FAN_UP, ButtonName.FAN_DOWN, ButtonName.TEMP_UP,
-                        ButtonName.TEMP_DOWN, ButtonName.FAN_DOWN, ButtonName.DEFROST_MAX, ButtonName.DEFROST_REAR, ButtonName.DEFROST, ButtonName.UPPER_VENT,
-                        ButtonName.LOWER_VENT, ButtonName.VOLUME_UP, ButtonName.VOLUME_DOWN, ButtonName.EJECT, ButtonName.SOURCE, ButtonName.SHUFFLE, ButtonName.REPEAT];
+                    const isRpcAllowed = (rpc) => {
+                        return this._permissionManager &&
+                            this._permissionManager.isRpcAllowed(rpc);
+                    };
 
-                    for (const buttonName of buttonNames) {
-                        await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this));
+                    if (!this._isButtonSubscriptionRequested && isRpcAllowed(SDL.rpc.enums.FunctionID.SubscribeButton)) {
+                        // add button listeners
+                        const screenManager = this._sdlManager.getScreenManager();
+                        const ButtonName = SDL.rpc.enums.ButtonName;
+                        const buttonNames = [ButtonName.PRESET_0, ButtonName.PRESET_1, ButtonName.PRESET_2, ButtonName.PRESET_3,
+                                    ButtonName.PRESET_4, ButtonName.PRESET_5, ButtonName.PRESET_6, ButtonName.PRESET_7, ButtonName.PRESET_8,
+                                    ButtonName.PRESET_9, ButtonName.PLAY_PAUSE, ButtonName.OK, ButtonName.SEEKLEFT, ButtonName.SEEKRIGHT,
+                                    ButtonName.TUNEUP, ButtonName.TUNEDOWN];
+
+                        for (const buttonName of buttonNames) {
+                            await screenManager.addButtonListener(buttonName, this._onButtonListener.bind(this))
+                                .catch((reason) => {
+                                    this._logRegularMessage(`Unable to subscribe to button: ${reason}`);
+                                });
+                        }
+
+                        this._isButtonSubscriptionRequested = true;
                     }
 
-                    if (!this._isTemplateSwitchCommandAdded && this._permissionManager && this._permissionManager.isRpcAllowed(SDL.rpc.enums.FunctionID.AddCommand)) {
+                    if (!this._isTemplateSwitchCommandAdded && isRpcAllowed(SDL.rpc.enums.FunctionID.AddCommand)) {
                         this._logRegularMessage('Adding return to WEB_VIEW template command');
                         this._isTemplateSwitchCommandAdded = true;
 


### PR DESCRIPTION
Fixes #321 and #320 and #323 

This PR **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Will be tested manually

### Summary
Logic of sending AddCommand and SubscribeButton for sample WEB_VIEW application were moved from OnHmiStatus callback to permissions change callback. This is more reliable way to trigger sending of initial RPCs as changing of HMI level is not always guarantees that RPC is allowed. Also, this is a more simple way to execute some blocks of code just once.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform) and this pull request adheres to the [Contributing Guide](./CONTRIBUTING.md). 
