### PR TITLE
Screen Manager Template Management

### DIFF
--- a/lib/js/src/manager/SystemCapabilityManager.js
+++ b/lib/js/src/manager/SystemCapabilityManager.js
@@ -580,6 +580,10 @@ class SystemCapabilityManager extends _SubManagerBase {
                 if (message.getMessageType() === MessageType.response) {
                     switch (FunctionID.valueForKey(message.getFunctionId())) {
                         case FunctionID.SetDisplayLayout:
+                            // If a setDisplayLayout fails, Capabilities did not change
+                            if (!message.getSuccess()) {
+                                return;
+                            }
                             this._displayCapabilities = message.getDisplayCapabilities();
                             this._buttonCapabilities = message.getButtonCapabilities();
                             this._presetBankCapabilities = message.getPresetBankCapabilities();

--- a/lib/js/src/manager/_SubManagerBase.js
+++ b/lib/js/src/manager/_SubManagerBase.js
@@ -170,7 +170,6 @@ class _SubManagerBase {
                 }
                 if (currentWindowId === PredefinedWindows.DEFAULT_WINDOW) {
                     // Check if the window capability is equal to the one we already have. If it is, abort.
-                    // TODO: What even am I going to do here
                     if (this._defaultMainWindowCapability !== null && this._defaultMainWindowCapability !== undefined && this._defaultMainWindowCapability.getParameters() === windowCapability.getParameters()) {
                         return;
                     }

--- a/lib/js/src/manager/_SubManagerBase.js
+++ b/lib/js/src/manager/_SubManagerBase.js
@@ -169,6 +169,11 @@ class _SubManagerBase {
                     currentWindowId = PredefinedWindows.DEFAULT_WINDOW;
                 }
                 if (currentWindowId === PredefinedWindows.DEFAULT_WINDOW) {
+                    // Check if the window capability is equal to the one we already have. If it is, abort.
+                    // TODO: What even am I going to do here
+                    if (this._defaultMainWindowCapability !== null && this._defaultMainWindowCapability !== undefined && this._defaultMainWindowCapability.getParameters() === windowCapability.getParameters()) {
+                        return;
+                    }
                     this._defaultMainWindowCapability = windowCapability;
                 }
             }

--- a/lib/js/src/manager/screen/_ScreenManagerBase.js
+++ b/lib/js/src/manager/screen/_ScreenManagerBase.js
@@ -374,7 +374,7 @@ class _ScreenManagerBase extends _SubManagerBase {
      * If you are connected on a < v6.0 connection and batching the update, the layout will be updated, then the text and graphics will be updated.
      * If you are connected on a >= v6.0 connection, the layout will be updated at the same time that the text and graphics are updated.
      *
-     * If this update is batched between beginTransaction and commit, the completionListener here will not be called. Use the completionListener with commit(completionListener)
+     * If this update is batched between beginTransaction and commit, the resolve here will not be called. As a result, you should not use await with this function when batching.
      *
      * NOTE: If this update returns an false, it may have been superseded by another update.
      * This means that it was cancelled while in-progress because another update was requested, whether batched or not.
@@ -451,7 +451,11 @@ class _ScreenManagerBase extends _SubManagerBase {
     }
 
     /**
-     * Send the updates that were started after beginning the transaction
+     * Pairs with beginTransaction() to batch text, graphic, and layout changes into a single update with a callback when the update is complete.
+     * Update text fields with new text set into the text field properties, updates the primary and secondary images with new image(s) if new one(s) been set,
+     * and updates the template if one was changed using changeLayout.
+     * NOTE: The resolve in changeLayout will not be called if the update is batched into this update
+     * NOTE: If this resolve returns false, it may have been superseded by another update. This means that it was cancelled while in-progress because another update was requested, whether batched or not
      * @returns {Promise} - Resolves to Boolean: whether the commit is a success
      */
     async commit () {

--- a/lib/js/src/manager/screen/_ScreenManagerBase.js
+++ b/lib/js/src/manager/screen/_ScreenManagerBase.js
@@ -83,7 +83,16 @@ class _ScreenManagerBase extends _SubManagerBase {
     }
 
     /**
-     * Set the textField1 on the head unit screen. Sending an empty String "" will clear the field
+     * The top text field within a template layout. Pass an empty string "" to clear the text field.
+     *
+     *  If the system does not support a full 4 fields, this will automatically be concatenated and properly send the field available.
+     *
+     *  If 3 lines are available: [field1, field2, field3 - field 4]
+     *
+     *  If 2 lines are available: [field1 - field2, field3 - field4]
+     *
+     *  If 1 line is available: [field1 - field2 - field3 - field4]
+     *
      * @param {String} textField1 - value represents the textField1
      * @returns {_ScreenManagerBase} - A reference to this instance to support method chaining.
      */
@@ -102,7 +111,16 @@ class _ScreenManagerBase extends _SubManagerBase {
     }
 
     /**
-     * Set the textField2 on the head unit screen. Sending an empty String "" will clear the field
+     * Sets the second text field within a template layout. Pass an empty string "" to clear the text field.
+	 *
+	 * If the system does not support a full 4 fields, this will automatically be concatenated and properly send the field available.
+	 *
+	 * If 3 lines are available: [field1, field2, field3 - field 4]
+	 *
+	 * If 2 lines are available: [field1 - field2, field3 - field4]
+	 *
+	 * If 1 line is available: [field1 - field2 - field3 - field4]
+	 *
      * @param {String} textField2 - value represents the textField1
      * @returns {_ScreenManagerBase} - A reference to this instance to support method chaining.
      */
@@ -120,7 +138,16 @@ class _ScreenManagerBase extends _SubManagerBase {
     }
 
     /**
-     * Set the textField3 on the head unit screen. Sending an empty String "" will clear the field
+     * Sets the third text field within a template layout. Pass an empty string "" to clear the text field.
+	 *
+	 * If the system does not support a full 4 fields, this will automatically be concatenated and properly send the field available.
+	 *
+	 * If 3 lines are available: [field1, field2, field3 - field 4]
+	 *
+	 * If 2 lines are available: [field1 - field2, field3 - field4]
+	 *
+	 * If 1 line is available: [field1 - field2 - field3 - field4]
+	 *
      * @param {String} textField3 - value represents the textField1
      * @returns {_ScreenManagerBase} - A reference to this instance to support method chaining.
      */
@@ -138,7 +165,16 @@ class _ScreenManagerBase extends _SubManagerBase {
     }
 
     /**
-     * Set the textField4 on the head unit screen. Sending an empty String "" will clear the field
+     * Sets the fourth text field within a template layout. Pass an empty string "" to clear the text field.
+	 *
+	 * If the system does not support a full 4 fields, this will automatically be concatenated and properly send the field available.
+	 *
+	 * If 3 lines are available: [field1, field2, field3 - field 4]
+	 *
+	 * If 2 lines are available: [field1 - field2, field3 - field4]
+	 *
+	 * If 1 line is available: [field1 - field2 - field3 - field4]
+	 *
      * @param {String} textField4 - value represents the textField1
      * @returns {_ScreenManagerBase} - A reference to this instance to support method chaining.
      */
@@ -328,6 +364,26 @@ class _ScreenManagerBase extends _SubManagerBase {
      */
     getTitle () {
         return this._textAndGraphicManager.getTitle();
+    }
+
+    /**
+	 * Change the current layout to a new layout and optionally update the layout's night and day color schemes. The values set for the text, graphics,
+	 * buttons and template title persist between layout changes. To update the text, graphics, buttons and template title at the same time as the template,
+	 * batch all the updates between beginTransaction and commit. If the layout update fails while batching, then the updated text, graphics, buttons or template title will also not be updated.
+	 *
+	 * If you are connected on a < v6.0 connection and batching the update, the layout will be updated, then the text and graphics will be updated.
+	 * If you are connected on a >= v6.0 connection, the layout will be updated at the same time that the text and graphics are updated.
+	 *
+	 * If this update is batched between beginTransaction and commit, the completionListener here will not be called. Use the completionListener with commit(completionListener)
+	 *
+	 * NOTE: If this update returns an false, it may have been superseded by another update.
+	 * This means that it was cancelled while in-progress because another update was requested, whether batched or not.
+	 *
+	 * @param templateConfiguration The new configuration of the template, including the layout and color scheme.
+     * @returns {Promise} 
+	 */
+    async changeLayout (templateConfiguration) {
+        return await this._textAndGraphicManager.changeLayout(templateConfiguration);
     }
 
     /**

--- a/lib/js/src/manager/screen/_ScreenManagerBase.js
+++ b/lib/js/src/manager/screen/_ScreenManagerBase.js
@@ -83,15 +83,15 @@ class _ScreenManagerBase extends _SubManagerBase {
     }
 
     /**
-     * The top text field within a template layout. Pass an empty string "" to clear the text field.
+     * The top text field within a template layout. Pass an empty string '' to clear the text field.
      *
-     *  If the system does not support a full 4 fields, this will automatically be concatenated and properly send the field available.
+     * If the system does not support a full 4 fields, this will automatically be concatenated and properly send the field available.
      *
-     *  If 3 lines are available: [field1, field2, field3 - field 4]
+     * If 3 lines are available: [field1, field2, field3 - field 4]
      *
-     *  If 2 lines are available: [field1 - field2, field3 - field4]
+     * If 2 lines are available: [field1 - field2, field3 - field4]
      *
-     *  If 1 line is available: [field1 - field2 - field3 - field4]
+     * If 1 line is available: [field1 - field2 - field3 - field4]
      *
      * @param {String} textField1 - value represents the textField1
      * @returns {_ScreenManagerBase} - A reference to this instance to support method chaining.
@@ -111,16 +111,16 @@ class _ScreenManagerBase extends _SubManagerBase {
     }
 
     /**
-     * Sets the second text field within a template layout. Pass an empty string "" to clear the text field.
-	 *
-	 * If the system does not support a full 4 fields, this will automatically be concatenated and properly send the field available.
-	 *
-	 * If 3 lines are available: [field1, field2, field3 - field 4]
-	 *
-	 * If 2 lines are available: [field1 - field2, field3 - field4]
-	 *
-	 * If 1 line is available: [field1 - field2 - field3 - field4]
-	 *
+     * Sets the second text field within a template layout. Pass an empty string '' to clear the text field.
+     *
+     * If the system does not support a full 4 fields, this will automatically be concatenated and properly send the field available.
+     *
+     * If 3 lines are available: [field1, field2, field3 - field 4]
+     *
+     * If 2 lines are available: [field1 - field2, field3 - field4]
+     *
+     * If 1 line is available: [field1 - field2 - field3 - field4]
+     *
      * @param {String} textField2 - value represents the textField1
      * @returns {_ScreenManagerBase} - A reference to this instance to support method chaining.
      */
@@ -138,16 +138,16 @@ class _ScreenManagerBase extends _SubManagerBase {
     }
 
     /**
-     * Sets the third text field within a template layout. Pass an empty string "" to clear the text field.
-	 *
-	 * If the system does not support a full 4 fields, this will automatically be concatenated and properly send the field available.
-	 *
-	 * If 3 lines are available: [field1, field2, field3 - field 4]
-	 *
-	 * If 2 lines are available: [field1 - field2, field3 - field4]
-	 *
-	 * If 1 line is available: [field1 - field2 - field3 - field4]
-	 *
+     * Sets the third text field within a template layout. Pass an empty string '' to clear the text field.
+     *
+     * If the system does not support a full 4 fields, this will automatically be concatenated and properly send the field available.
+     *
+     * If 3 lines are available: [field1, field2, field3 - field 4]
+     *
+     * If 2 lines are available: [field1 - field2, field3 - field4]
+     *
+     * If 1 line is available: [field1 - field2 - field3 - field4]
+     *
      * @param {String} textField3 - value represents the textField1
      * @returns {_ScreenManagerBase} - A reference to this instance to support method chaining.
      */
@@ -166,15 +166,15 @@ class _ScreenManagerBase extends _SubManagerBase {
 
     /**
      * Sets the fourth text field within a template layout. Pass an empty string "" to clear the text field.
-	 *
-	 * If the system does not support a full 4 fields, this will automatically be concatenated and properly send the field available.
-	 *
-	 * If 3 lines are available: [field1, field2, field3 - field 4]
-	 *
-	 * If 2 lines are available: [field1 - field2, field3 - field4]
-	 *
-	 * If 1 line is available: [field1 - field2 - field3 - field4]
-	 *
+     *
+     * If the system does not support a full 4 fields, this will automatically be concatenated and properly send the field available.
+     *
+     * If 3 lines are available: [field1, field2, field3 - field 4]
+     *
+     * If 2 lines are available: [field1 - field2, field3 - field4]
+     *
+     * If 1 line is available: [field1 - field2 - field3 - field4]
+     *
      * @param {String} textField4 - value represents the textField1
      * @returns {_ScreenManagerBase} - A reference to this instance to support method chaining.
      */
@@ -367,23 +367,25 @@ class _ScreenManagerBase extends _SubManagerBase {
     }
 
     /**
-	 * Change the current layout to a new layout and optionally update the layout's night and day color schemes. The values set for the text, graphics,
-	 * buttons and template title persist between layout changes. To update the text, graphics, buttons and template title at the same time as the template,
-	 * batch all the updates between beginTransaction and commit. If the layout update fails while batching, then the updated text, graphics, buttons or template title will also not be updated.
-	 *
-	 * If you are connected on a < v6.0 connection and batching the update, the layout will be updated, then the text and graphics will be updated.
-	 * If you are connected on a >= v6.0 connection, the layout will be updated at the same time that the text and graphics are updated.
-	 *
-	 * If this update is batched between beginTransaction and commit, the completionListener here will not be called. Use the completionListener with commit(completionListener)
-	 *
-	 * NOTE: If this update returns an false, it may have been superseded by another update.
-	 * This means that it was cancelled while in-progress because another update was requested, whether batched or not.
-	 *
-	 * @param templateConfiguration The new configuration of the template, including the layout and color scheme.
-     * @returns {Promise} 
-	 */
+     * Change the current layout to a new layout and optionally update the layout's night and day color schemes. The values set for the text, graphics,
+     * buttons and template title persist between layout changes. To update the text, graphics, buttons and template title at the same time as the template,
+     * batch all the updates between beginTransaction and commit. If the layout update fails while batching, then the updated text, graphics, buttons or template title will also not be updated.
+     *
+     * If you are connected on a < v6.0 connection and batching the update, the layout will be updated, then the text and graphics will be updated.
+     * If you are connected on a >= v6.0 connection, the layout will be updated at the same time that the text and graphics are updated.
+     *
+     * If this update is batched between beginTransaction and commit, the completionListener here will not be called. Use the completionListener with commit(completionListener)
+     *
+     * NOTE: If this update returns an false, it may have been superseded by another update.
+     * This means that it was cancelled while in-progress because another update was requested, whether batched or not.
+     *
+     * @param {TemplateConfiguration} templateConfiguration - The new configuration of the template, including the layout and color scheme.
+     * @returns {Promise} - Resolves to Boolean: whether the update is successful
+     */
     async changeLayout (templateConfiguration) {
-        return await this._textAndGraphicManager.changeLayout(templateConfiguration);
+        return new Promise((resolve) => {
+            this._textAndGraphicManager.changeLayout(templateConfiguration, resolve);
+        });
     }
 
     /**

--- a/lib/js/src/manager/screen/_TextAndGraphicManagerBase.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicManagerBase.js
@@ -126,9 +126,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
                 resolve(false);
             }
             if (this._isDirty) {
-                const task = new _Task();
-                task.onExecute = this._sdlUpdate(true, resolve);
-                this._addTask(task);
+                this._sdlUpdate(true, resolve);
             } else {
                 resolve(true);
             }
@@ -138,40 +136,43 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     /**
      * Determines what needs to be done to send a valid Show method
      * @private
-     * @param {Boolean} supersedePreviousOperations - 
+     * @param {Boolean} supersedePreviousOperations - Whether this update should have priority over previous updates
      * @param {function} listener - A function to invoke when the update task is complete once it runs
-     * @returns {function} - An async function that returns after this update is done
      */
     _sdlUpdate (supersedePreviousOperations, listener) {
-        return async () => {
-            if (this._updateOperation !== null && this._updateOperation.getState() === _Task.READY && supersedePreviousOperations) {
-                this._updateOperation.switchStates(_Task.CANCELED);
+        if (this._updateOperation !== null && this._updateOperation.getState() === _Task.READY && supersedePreviousOperations) {
+            this._updateOperation.switchStates(_Task.CANCELED);
+            if (typeof this._currentOperationListener === 'function') {
                 this._currentOperationListener(false);
             }
+        }
 
-            if (this._updateOperation !== null && this._updateOperation.getState() === _Task.IN_PROGRESS && supersedePreviousOperations) {
-                this._updateOperation.switchStates(_Task.CANCELED);
-            }
+        if (this._updateOperation !== null && this._updateOperation.getState() === _Task.IN_PROGRESS && supersedePreviousOperations) {
+            this._updateOperation.switchStates(_Task.CANCELED);
+        }
 
-            this._currentOperationListener = listener;
+        this._currentOperationListener = listener;
 
-            const currentScreenDataUpdateListener = async function (asyncListener) {
-                await asyncListener().then(function (newScreenData) {
-                    if (newScreenData !== null) {
-                        this._currentScreenData = newScreenData;
-                        this._updatePendingOperationsWithNewScreenData();
-                    }
-                }).catch(function () {
-                    this._resetFieldsToCurrentScreenData();
-                });
-            };
-
-            this._updateOperation = new _TextAndGraphicUpdateOperation(this._lifecycleManager, this._fileManager, this._defaultMainWindowCapability,
-                this._currentScreenData, this._currentState(), this._currentOperationListener, currentScreenDataUpdateListener.bind(this));
-            this._addTask(this._updateOperation);
+        const currentScreenDataUpdateListener = async function (asyncListener) {
+            await asyncListener().then(function (newScreenData) {
+                if (newScreenData !== null) {
+                    this._currentScreenData = newScreenData;
+                    this._updatePendingOperationsWithNewScreenData();
+                }
+            }).catch(function () {
+                this._resetFieldsToCurrentScreenData();
+            }.bind(this));
         };
+
+        this._updateOperation = new _TextAndGraphicUpdateOperation(this._lifecycleManager, this._fileManager, this._defaultMainWindowCapability,
+            this._currentScreenData, this._currentState(), this._currentOperationListener, currentScreenDataUpdateListener.bind(this));
+        this._addTask(this._updateOperation);
     }
 
+    /**
+     * Resets all properties to the values of the currentScreenData
+     * @private
+     */
     _resetFieldsToCurrentScreenData () {
         this._textField1 = this._currentScreenData.getTextField1();
         this._textField2 = this._currentScreenData.getTextField2();
@@ -191,7 +192,6 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
 
     /**
      * Updates all pending tasks in the queue with the current screen data
-     * @param {Show} newScreenData - A Show consisting of the current screen data from the HMI
      */
     _updatePendingOperationsWithNewScreenData () {
         for (const task in this._getTasks()) {
@@ -236,7 +236,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextAlignment (textAlignment) {
         this._textAlignment = textAlignment;
         if (!this._batchingUpdates) {
-            this.update();
+            this._sdlUpdate(true, null);
         } else {
             this._isDirty = true;
         }
@@ -259,7 +259,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setMediaTrackTextField (mediaTrackTextField) {
         this._mediaTrackTextField = mediaTrackTextField;
         if (!this._batchingUpdates) {
-            this.update();
+            this._sdlUpdate(true, null);
         } else {
             this._isDirty = true;
         }
@@ -282,7 +282,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField1 (textField1) {
         this._textField1 = textField1;
         if (!this._batchingUpdates) {
-            this.update();
+            this._sdlUpdate(true, null);
         } else {
             this._isDirty = true;
         }
@@ -305,7 +305,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField2 (textField2) {
         this._textField2 = textField2;
         if (!this._batchingUpdates) {
-            this.update();
+            this._sdlUpdate(true, null);
         } else {
             this._isDirty = true;
         }
@@ -328,7 +328,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField3 (textField3) {
         this._textField3 = textField3;
         if (!this._batchingUpdates) {
-            this.update();
+            this._sdlUpdate(true, null);
         } else {
             this._isDirty = true;
         }
@@ -351,7 +351,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField4 (textField4) {
         this._textField4 = textField4;
         if (!this._batchingUpdates) {
-            this.update();
+            this._sdlUpdate(true, null);
         } else {
             this._isDirty = true;
         }
@@ -374,7 +374,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField1Type (textField1Type) {
         this._textField1Type = textField1Type;
         if (!this._batchingUpdates) {
-            this.update();
+            this._sdlUpdate(true, null);
         } else {
             this._isDirty = true;
         }
@@ -397,7 +397,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField2Type (textField2Type) {
         this._textField2Type = textField2Type;
         if (!this._batchingUpdates) {
-            this.update();
+            this._sdlUpdate(true, null);
         } else {
             this._isDirty = true;
         }
@@ -420,7 +420,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField3Type (textField3Type) {
         this._textField3Type = textField3Type;
         if (!this._batchingUpdates) {
-            this.update();
+            this._sdlUpdate(true, null);
         } else {
             this._isDirty = true;
         }
@@ -443,7 +443,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField4Type (textField4Type) {
         this._textField4Type = textField4Type;
         if (!this._batchingUpdates) {
-            this.update();
+            this._sdlUpdate(true, null);
         } else {
             this._isDirty = true;
         }
@@ -466,7 +466,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTitle (title) {
         this._title = title;
         if (!this._batchingUpdates) {
-            this.update();
+            this._sdlUpdate(true, null);
         } else {
             this._isDirty = true;
         }
@@ -489,7 +489,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setPrimaryGraphic (primaryGraphic) {
         this._primaryGraphic = primaryGraphic;
         if (!this._batchingUpdates) {
-            this.update();
+            this._sdlUpdate(true, null);
         } else {
             this._isDirty = true;
         }
@@ -512,7 +512,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setSecondaryGraphic (secondaryGraphic) {
         this._secondaryGraphic = secondaryGraphic;
         if (!this._batchingUpdates) {
-            this.update();
+            this._sdlUpdate(true, null);
         } else {
             this._isDirty = true;
         }
@@ -527,22 +527,35 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
         return this._secondaryGraphic;
     }
 
-    changeLayout (templateConfiguration) {
-        this._setTemplateConfiguration(templateConfiguration);
+    /**
+     * Change the templateConfiguration
+     * @param {TemplateConfiguration} templateConfiguration - An instance of TemplateConfiguration.
+     * @param {function} listener - A function to be called when the update has completed
+     */
+    changeLayout (templateConfiguration, listener) {
+        this.setTemplateConfiguration(templateConfiguration);
         if (!this._batchingUpdates) {
-            this.update();
+            this._sdlUpdate(true, listener);
         } else {
             this._isDirty = true;
         }
     }
 
+    /**
+     * Get templateConfiguration
+     * @returns {TemplateConfiguration} - An instance of TemplateConfiguration.
+     */
     getTemplateConfiguration () {
         return this._templateConfiguration;
     }
 
+    /**
+     * Set templateConfiguration
+     * @param {TemplateConfiguration} templateConfiguration - An instance of TemplateConfiguration.
+     */
     setTemplateConfiguration (templateConfiguration) {
-        // Don't do the `isBatchingUpdates` like elsewhere because the call is already handled in `changeLayout(TemplateConfiguration templateConfiguration, CompletionListener listener) `
-        this.templateConfiguration = templateConfiguration;
+        // Don't do the `isBatchingUpdates` like elsewhere because the call is already handled in `changeLayout(TemplateConfiguration templateConfiguration) `
+        this._templateConfiguration = templateConfiguration;
     }
 
     /**

--- a/lib/js/src/manager/screen/_TextAndGraphicManagerBase.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicManagerBase.js
@@ -51,7 +51,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
         this._softButtonManager = softButtonManager;
         this._batchingUpdates = false; // whether to wait on sending the updates
         this._blankArtwork = null;
-        this._currentScreenData = new Show();
+        this._currentScreenData = new _TextAndGraphicState();
 
         this._primaryGraphic = null;
         this._secondaryGraphic = null;
@@ -69,6 +69,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
         this._isDirty = false;
         this._updateOperation = null;
         this._currentOperationListener = null;
+        this._templateConfiguration = null;
 
         this._handleDisplayCapabilityUpdates();
         this._handleTaskQueue();
@@ -126,7 +127,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
             }
             if (this._isDirty) {
                 const task = new _Task();
-                task.onExecute = this._sdlUpdate(resolve);
+                task.onExecute = this._sdlUpdate(true, resolve);
                 this._addTask(task);
             } else {
                 resolve(true);
@@ -137,25 +138,32 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     /**
      * Determines what needs to be done to send a valid Show method
      * @private
+     * @param {Boolean} supersedePreviousOperations - 
      * @param {function} listener - A function to invoke when the update task is complete once it runs
      * @returns {function} - An async function that returns after this update is done
      */
-    _sdlUpdate (listener) {
+    _sdlUpdate (supersedePreviousOperations, listener) {
         return async () => {
-            if (this._updateOperation !== null && this._updateOperation.getState() === _Task.READY) {
+            if (this._updateOperation !== null && this._updateOperation.getState() === _Task.READY && supersedePreviousOperations) {
                 this._updateOperation.switchStates(_Task.CANCELED);
                 this._currentOperationListener(false);
             }
 
-            if (this._updateOperation !== null && this._updateOperation.getState() === _Task.IN_PROGRESS) {
+            if (this._updateOperation !== null && this._updateOperation.getState() === _Task.IN_PROGRESS && supersedePreviousOperations) {
                 this._updateOperation.switchStates(_Task.CANCELED);
             }
 
             this._currentOperationListener = listener;
 
-            const currentScreenDataUpdateListener = function (show) {
-                this._updatePendingOperationsWithNewScreenData(show);
-                this._currentScreenData = show;
+            const currentScreenDataUpdateListener = async function (asyncListener) {
+                await asyncListener().then(function (newScreenData) {
+                    if (newScreenData !== null) {
+                        this._currentScreenData = newScreenData;
+                        this._updatePendingOperationsWithNewScreenData();
+                    }
+                }).catch(function () {
+                    this._resetFieldsToCurrentScreenData();
+                });
             };
 
             this._updateOperation = new _TextAndGraphicUpdateOperation(this._lifecycleManager, this._fileManager, this._defaultMainWindowCapability,
@@ -164,19 +172,36 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
         };
     }
 
+    _resetFieldsToCurrentScreenData () {
+        this._textField1 = this._currentScreenData.getTextField1();
+        this._textField2 = this._currentScreenData.getTextField2();
+        this._textField3 = this._currentScreenData.getTextField3();
+        this._textField4 = this._currentScreenData.getTextField4();
+        this._mediaTrackTextField = this._currentScreenData.getMediaTrackTextField();
+        this._title = this._currentScreenData.getTitle();
+        this._textAlignment = this._currentScreenData.getTextAlignment();
+        this._textField1Type = this._currentScreenData.getTextField1Type();
+        this._textField2Type = this._currentScreenData.getTextField2Type();
+        this._textField3Type = this._currentScreenData.getTextField3Type();
+        this._textField4Type = this._currentScreenData.getTextField4Type();
+        this._primaryGraphic = this._currentScreenData.getPrimaryGraphic();
+        this._secondaryGraphic = this._currentScreenData.getSecondaryGraphic();
+        this._templateConfiguration = this._currentScreenData.getTemplateConfiguration();
+    }
+
     /**
      * Updates all pending tasks in the queue with the current screen data
      * @param {Show} newScreenData - A Show consisting of the current screen data from the HMI
      */
-    _updatePendingOperationsWithNewScreenData (newScreenData) {
+    _updatePendingOperationsWithNewScreenData () {
         for (const task in this._getTasks()) {
             if (!(task instanceof _TextAndGraphicUpdateOperation)) {
                 continue;
             }
-            task._setCurrentScreenData(newScreenData);
+            task._setCurrentScreenData(this._currentScreenData);
         }
-        if (this._softButtonManager !== null && newScreenData.getMainField1() !== null) {
-            this._softButtonManager.setCurrentMainField1(this._currentScreenData.getMainField1());
+        if (this._softButtonManager !== null && this._currentScreenData.getTextField1() !== null) {
+            this._softButtonManager.setCurrentMainField1(this._currentScreenData.getTextField1());
         }
     }
 
@@ -198,7 +223,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     _currentState () {
         return new _TextAndGraphicState(this._textField1, this._textField2, this._textField3, this._textField4,
             this._mediaTrackTextField, this._title, this._primaryGraphic, this._secondaryGraphic, this._textAlignment,
-            this._textField1Type, this._textField2Type, this._textField3Type, this._textField4Type);
+            this._textField1Type, this._textField2Type, this._textField3Type, this._textField4Type, this._templateConfiguration);
     }
 
     // SCREEN ITEM SETTERS AND GETTERS
@@ -500,6 +525,24 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
      */
     getSecondaryGraphic () {
         return this._secondaryGraphic;
+    }
+
+    changeLayout (templateConfiguration) {
+        this._setTemplateConfiguration(templateConfiguration);
+        if (!this._batchingUpdates) {
+            this.update();
+        } else {
+            this._isDirty = true;
+        }
+    }
+
+    getTemplateConfiguration () {
+        return this._templateConfiguration;
+    }
+
+    setTemplateConfiguration (templateConfiguration) {
+        // Don't do the `isBatchingUpdates` like elsewhere because the call is already handled in `changeLayout(TemplateConfiguration templateConfiguration, CompletionListener listener) `
+        this.templateConfiguration = templateConfiguration;
     }
 
     /**

--- a/lib/js/src/manager/screen/_TextAndGraphicManagerBase.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicManagerBase.js
@@ -32,7 +32,6 @@
 
 import { _SubManagerBase } from '../_SubManagerBase.js';
 import { _Task } from '../_Task.js';
-import { Show } from '../../rpc/messages/Show.js';
 import { _TextAndGraphicUpdateOperation } from './_TextAndGraphicUpdateOperation.js';
 import { _TextAndGraphicState } from './_TextAndGraphicState.js';
 
@@ -92,7 +91,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
         // remove listeners
         this._batchingUpdates = false;
         this._blankArtwork = null;
-        this._currentScreenData = new Show();
+        this._currentScreenData = new _TextAndGraphicState();
 
         this._primaryGraphic = null;
         this._secondaryGraphic = null;
@@ -153,15 +152,15 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
 
         this._currentOperationListener = listener;
 
-        const currentScreenDataUpdateListener = async function (asyncListener) {
-            await asyncListener().then(function (newScreenData) {
+        const currentScreenDataUpdateListener = (asyncListener) => {
+            asyncListener().then((newScreenData) => {
                 if (newScreenData !== null) {
                     this._currentScreenData = newScreenData;
                     this._updatePendingOperationsWithNewScreenData();
                 }
-            }).catch(function () {
+            }).catch((err) => {
                 this._resetFieldsToCurrentScreenData();
-            }.bind(this));
+            });
         };
 
         this._updateOperation = new _TextAndGraphicUpdateOperation(this._lifecycleManager, this._fileManager, this._defaultMainWindowCapability,

--- a/lib/js/src/manager/screen/_TextAndGraphicState.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicState.js
@@ -30,6 +30,8 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
+import { TemplateConfiguration } from "../../rpc/structs/TemplateConfiguration";
+
 class _TextAndGraphicState {
     /**
      * Initializes an instance of _TextAndGraphicState
@@ -46,10 +48,12 @@ class _TextAndGraphicState {
      * @param {MetadataType} textField2Type - The field type
      * @param {MetadataType} textField3Type - The field type
      * @param {MetadataType} textField4Type - The field type
+     * @param {TemplateConfiguration} templateConfiguration - A TemplateConfiguration struct
      */
     constructor (textField1, textField2, textField3, textField4, mediaTrackTextField,
         title, primaryGraphic, secondaryGraphic, textAlignment,
-        textField1Type, textField2Type, textField3Type, textField4Type) {
+        textField1Type, textField2Type, textField3Type, textField4Type,
+        templateConfiguration) {
         this._textField1 = textField1;
         this._textField2 = textField2;
         this._textField3 = textField3;
@@ -63,6 +67,7 @@ class _TextAndGraphicState {
         this._textField2Type = textField2Type;
         this._textField3Type = textField3Type;
         this._textField4Type = textField4Type;
+        this._templateConfiguration = templateConfiguration;
     }
 
     /**
@@ -233,6 +238,10 @@ class _TextAndGraphicState {
         return this._textAlignment;
     }
 
+    setTextAlignment (textAlignment) {
+        this._textAlignment = textAlignment;
+    }
+
     /**
      * Get primaryGraphic
      * @returns {SdlArtwork} - An instance of SdlArtwork.
@@ -241,12 +250,28 @@ class _TextAndGraphicState {
         return this._primaryGraphic;
     }
 
+    setPrimaryGraphic (primaryGraphic) {
+        this._primaryGraphic = primaryGraphic;
+    }
+
     /**
      * Get secondaryGraphic
      * @returns {SdlArtwork} - An instance of SdlArtwork.
      */
     getSecondaryGraphic () {
         return this._secondaryGraphic;
+    }
+
+    setSecondaryGraphic (secondaryGraphic) {
+        this._secondaryGraphic = secondaryGraphic;
+    }
+
+    getTemplateConfiguration () {
+        return this._templateConfiguration;
+    }
+
+    setTemplateConfiguration (templateConfiguration) {
+        this._templateConfiguration = templateConfiguration;
     }
 }
 

--- a/lib/js/src/manager/screen/_TextAndGraphicState.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicState.js
@@ -30,8 +30,6 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-import { TemplateConfiguration } from "../../rpc/structs/TemplateConfiguration";
-
 class _TextAndGraphicState {
     /**
      * Initializes an instance of _TextAndGraphicState
@@ -238,6 +236,10 @@ class _TextAndGraphicState {
         return this._textAlignment;
     }
 
+    /**
+     * Set textAlignment
+     * @param {TextAlignment} textAlignment - A TextAlignment enum value.
+     */
     setTextAlignment (textAlignment) {
         this._textAlignment = textAlignment;
     }
@@ -250,6 +252,10 @@ class _TextAndGraphicState {
         return this._primaryGraphic;
     }
 
+    /**
+     * Set primaryGraphic
+     * @param {SdlArtwork} primaryGraphic - An instance of SdlArtwork.
+     */
     setPrimaryGraphic (primaryGraphic) {
         this._primaryGraphic = primaryGraphic;
     }
@@ -262,14 +268,26 @@ class _TextAndGraphicState {
         return this._secondaryGraphic;
     }
 
+    /**
+     * Set secondaryGraphic
+     * @param {SdlArtwork} secondaryGraphic - An instance of SdlArtwork.
+     */
     setSecondaryGraphic (secondaryGraphic) {
         this._secondaryGraphic = secondaryGraphic;
     }
 
+    /**
+     * Get templateConfiguration
+     * @returns {TemplateConfiguration} - An instance of TemplateConfiguration.
+     */
     getTemplateConfiguration () {
         return this._templateConfiguration;
     }
 
+    /**
+     * Set templateConfiguration
+     * @param {TemplateConfiguration} templateConfiguration - An instance of TemplateConfiguration.
+     */
     setTemplateConfiguration (templateConfiguration) {
         this._templateConfiguration = templateConfiguration;
     }

--- a/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
@@ -36,6 +36,9 @@ import { ImageFieldName } from '../../rpc/enums/ImageFieldName';
 import { _ManagerUtility } from '../_ManagerUtility';
 import { MetadataTags } from '../../rpc/structs/MetadataTags';
 import { TextFieldName } from '../../rpc/enums/TextFieldName';
+import { SetDisplayLayout } from '../../rpc/messages/SetDisplayLayout';
+import { TemplateConfiguration } from '../../rpc/structs/TemplateConfiguration';
+import { _TextAndGraphicState } from './_TextAndGraphicState';
 
 class _TextAndGraphicUpdateOperation extends _Task {
     /**
@@ -43,7 +46,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
      * @param {_LifecycleManager} lifecycleManager - A _LifecycleManager instance
      * @param {FileManager} fileManager - A FileManager instance
      * @param {WindowCapability} currentCapabilities - The capabilities of the default main window
-     * @param {Show} currentScreenData - The current state of the screen
+     * @param {_TextAndGraphicState} currentScreenData - The current state of the screen
      * @param {_TextAndGraphicState} newState - The updated state of the screen
      * @param {Function} listener - A method to be called when the task is completed
      * @param {Function} currentScreenDataUpdateListener - A method to update the current screen data
@@ -57,6 +60,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
         this._updatedState = newState;
         this._listener = listener;
         this._currentScreenDataUpdateListener = currentScreenDataUpdateListener;
+        this._fullShow = null;
     }
 
     /**
@@ -75,22 +79,41 @@ class _TextAndGraphicUpdateOperation extends _Task {
             this._finishOperation(false);
             return;
         }
-        let fullShow = new Show().setAlignment(this._updatedState.getTextAlignment());
-        fullShow = this._assembleShowText(fullShow);
-        fullShow = this._assembleShowImages(fullShow);
+        this._fullShow = new Show().setAlignment(this._updatedState.getTextAlignment());
+        this._fullShow = this._assembleShowText(this._fullShow);
+        this._fullShow = this._assembleShowImages(this._fullShow);
+        this._fullShow = this._assembleLayout(this._fullShow);
 
+        if (this._showRPCSupportsTemplateConfiguration()) {
+            this._updateGraphicsAndShow(this._fullShow);
+        } else {
+            if (this._shouldUpdateTemplateConfig()) {
+                const success = await this._sendSetDisplayLayoutWithTemplateConfiguration(this._updatedState.getTemplateConfiguration());
+                if (this.getState() === _Task.CANCELED || !success) {
+                    // Task was canceled or SetDisplayLayout was not a success
+                    this._finishOperation(false);
+                    return;
+                }
+                this._updateGraphicsAndShow(this._fullShow);
+            } else {
+                this._updateGraphicsAndShow(this._fullShow);
+            }
+        }
+    }
+
+    async _updateGraphicsAndShow (show) {
         if (!this._shouldUpdatePrimaryImage() && !this._shouldUpdateSecondaryImage()) {
             console.info('No images to send, sending text');
-            const success = await this._sendShow(this._extractTextFromShow(fullShow));
+            const success = await this._sendShow(this._extractTextAndLayoutFromShow(show));
             this._finishOperation(success);
         } else if (!this._sdlArtworkNeedsUpload(this._updatedState.getPrimaryGraphic()) &&
             !this._sdlArtworkNeedsUpload(this._updatedState.getSecondaryGraphic())) {
             console.info('Images already uploaded, sending full update');
-            const success = await this._sendShow(fullShow);
+            const success = await this._sendShow(show);
             this._finishOperation(success);
         } else {
             console.info('Images need to be uploaded, sending text and uploading images');
-            const success = await this._sendShow(this._extractTextFromShow(fullShow));
+            const success = await this._sendShow(this._extractTextAndLayoutFromShow(show));
             if (this.getState() === _Task.CANCELED) {
                 this._finishOperation(false);
                 return;
@@ -107,12 +130,41 @@ class _TextAndGraphicUpdateOperation extends _Task {
      * @returns {Promise} - Resolves to a Boolean
      */
     async _sendShow (show) {
-        const response = await this._lifecycleManager.sendRpcResolve(show);
-        console.info('Text and Graphic update complete');
-        if (response.getSuccess()) {
-            this._updateCurrentScreenDataFromShow(show);
+        if (this._lifecycleManager !== null) {
+            const response = await this._lifecycleManager.sendRpcResolve(show);
+            if (response.getSuccess()) {
+                console.info('Text and Graphic update complete');
+                this._updateCurrentScreenDataFromShow(show);
+            } else {
+                console.info('Text and Graphic Show failed');
+            }
+            return response.getSuccess();
+        } else {
+            console.info('LifecycleManager is null, Text and Graphic update failed');
+            this._currentScreenDataUpdateListener(async () => {
+                throw new Error('LifecycleManager is null, Text and Graphic update failed');
+            });
+            this._finishOperation(false);
+            return;
         }
-        return response.getSuccess();
+    }
+
+    async _sendSetDisplayLayoutWithTemplateConfiguration (configuration) {
+        const setLayout = new SetDisplayLayout(configuration.getTemplate()).setDayColorScheme(configuration.getDayColorScheme()).setNightColorScheme(configuration.getNightColorScheme());
+        if (this._lifecycleManager !== null) {
+            const response = await this._lifecycleManager.sendRpcResolve(setLayout);
+            if (response.getSuccess()) {
+                this._updateCurrentScreenDataFromSetDisplayLayout(setLayout);
+            } else {
+                console.info('Text and Graphic SetDisplayLayout failed');
+            }
+            return response.getSuccess();
+        } else {
+            console.info('LifecycleManager is null, Text and Graphic update failed');
+
+            this._finishOperation(false);
+            return;
+        }
     }
 
     /**
@@ -226,7 +278,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
             return show;
         }
 
-        const numberOfLines = (this._defaultMainWindowCapability !== null && this._defaultMainWindowCapability !== undefined) ? _ManagerUtility.getMaxNumberOfMainFieldLines(this._defaultMainWindowCapability) : 4;
+        const numberOfLines = (this._defaultMainWindowCapability === null && this._defaultMainWindowCapability === undefined) || this._shouldUpdateTemplateConfig() ? 4 : _ManagerUtility.getMaxNumberOfMainFieldLines(this._defaultMainWindowCapability);
         switch (numberOfLines) {
             case 1:
                 show = this._assembleOneLineShowText(show, nonNullFields);
@@ -461,7 +513,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
      * @param {Show} show - A Show RPC Message.
      * @returns {Show} - A new Show RPC Message.
      */
-    _extractTextFromShow (show) {
+    _extractTextAndLayoutFromShow (show) {
         const newShow = new Show();
         newShow.setMainField1(show.getMainField1());
         newShow.setMainField2(show.getMainField2());
@@ -471,6 +523,9 @@ class _TextAndGraphicUpdateOperation extends _Task {
         newShow.setMetadataTags(show.getMetadataTags());
         newShow.setAlignment(show.getAlignment());
 
+        if (this._showRPCSupportsTemplateConfiguration()) {
+            newShow.setTemplateConfiguration(show.getTemplateConfiguration());
+        }
         return newShow;
     }
 
@@ -490,6 +545,23 @@ class _TextAndGraphicUpdateOperation extends _Task {
         return show;
     }
 
+    _assembleLayout (show) {
+        if (!this._showRPCSupportsTemplateConfiguration() || !this._shouldUpdateTemplateConfig()) {
+            return show;
+        }
+        show.setTemplateConfiguration(this._updatedState.getTemplateConfiguration());
+        return show;
+    }
+
+    _updateCurrentScreenDataFromSetDisplayLayout (setDisplayLayout) {
+        this._currentScreenData.setTemplateConfiguration(new TemplateConfiguration().setTemplate(setDisplayLayout.getDisplayLayout()).setDayColorScheme(setDisplayLayout.getDayColorScheme()).setNightColorScheme(setDisplayLayout.getNightColorScheme()));
+        if (this._currentScreenDataUpdateListener !== null) {
+            this._currentScreenDataUpdateListener(async function () {
+                return Promise.resolve(this._currentScreenData);
+            });
+        }
+    }
+
     /**
      * Updates the local state to match what was sent
      * @private
@@ -501,40 +573,63 @@ class _TextAndGraphicUpdateOperation extends _Task {
             return;
         }
 
-        // If the items are null, they were not updated, so we can't just set it directly
+        // This is intentionally checking `mainField1` for every textField because the fields may be in different places based on the capabilities, then check it's own field in case that's the only field thats being used.
         if (show.getMainField1() !== null && show.getMainField1() !== undefined) {
-            this._currentScreenData.setMainField1(show.getMainField1());
+            this._currentScreenData.setTextField1(this._updatedState.getTextField1());
         }
-        if (show.getMainField2() !== null && show.getMainField2() !== undefined) {
-            this._currentScreenData.setMainField2(show.getMainField2());
+        if ((show.getMainField1() !== null && show.getMainField1() !== undefined) || (show.getMainField2() !== null && show.getMainField2() !== undefined)) {
+            this._currentScreenData.setTextField2(this._updatedState.getTextField2());
         }
-        if (show.getMainField3() !== null && show.getMainField3() !== undefined) {
-            this._currentScreenData.setMainField3(show.getMainField3());
+        if ((show.getMainField1() !== null && show.getMainField1() !== undefined) || (show.getMainField3() !== null && show.getMainField3() !== undefined)) {
+            this._currentScreenData.setTextField3(this._updatedState.getTextField3());
         }
-        if (show.getMainField4() !== null && show.getMainField4() !== undefined) {
-            this._currentScreenData.setMainField4(show.getMainField4());
+        if ((show.getMainField1() !== null && show.getMainField1() !== undefined) || (show.getMainField4() !== null && show.getMainField4() !== undefined)) {
+            this._currentScreenData.setTextField4(this._updatedState.getTextField4());
         }
         if (show.getTemplateTitle() !== null && show.getTemplateTitle() !== undefined) {
-            this._currentScreenData.setTemplateTitle(show.getTemplateTitle());
+            this._currentScreenData.setTitle(this._updatedState.getTitle());
         }
         if (show.getMediaTrack() !== null && show.getMediaTrack() !== undefined) {
-            this._currentScreenData.setMediaTrack(show.getMediaTrack());
+            this._currentScreenData.setMediaTrackTextField(this._updatedState.getMediaTrackTextField());
         }
+
+        // This is intentionally checking show.metadataTags.mainField1 because the tags may be in different places based on the capabilities, then check its own field in case that's the only field that's being used.
         if (show.getMetadataTags() !== null && show.getMetadataTags() !== undefined) {
-            this._currentScreenData.setMetadataTags(show.getMetadataTags());
+            if (show.getMetadataTags().getMainField1() !== null && show.getMetadataTags().getMainField1() !== undefined) {
+                this._currentScreenData.setTextField1Type(this._updatedState.getTextField1Type());
+            }
+            if ((show.getMetadataTags().getMainField1() !== null && show.getMetadataTags().getMainField1() !== undefined) || (show.getMetadataTags().getMainField2() !== null && show.getMetadataTags().getMainField2() !== undefined)) {
+                this._currentScreenData.setTextField2Type(this._updatedState.getTextField2Type());
+            }
+            if ((show.getMetadataTags().getMainField1() !== null && show.getMetadataTags().getMainField1() !== undefined) || (show.getMetadataTags().getMainField3() !== null && show.getMetadataTags().getMainField3() !== undefined)) {
+                this._currentScreenData.setTextField3Type(this._updatedState.getTextField3Type());
+            }
+            if ((show.getMetadataTags().getMainField1() !== null && show.getMetadataTags().getMainField1() !== undefined) || (show.getMetadataTags().getMainField4() !== null && show.getMetadataTags().getMainField4() !== undefined)) {
+                this._currentScreenData.setTextField4Type(this._updatedState.getTextField4Type());
+            }
         }
+
         if (show.getAlignment() !== null && show.getAlignment() !== undefined) {
-            this._currentScreenData.setAlignment(show.getAlignment());
+            this._currentScreenData.setTextAlignment(this._updatedState.getTextAlignment());
         }
         if (show.getGraphic() !== null && show.getGraphic() !== undefined) {
-            this._currentScreenData.setGraphic(show.getGraphic());
+            this._currentScreenData.setPrimaryGraphic(this._updatedState.getPrimaryGraphic());
         }
         if (show.getSecondaryGraphic() !== null && show.getSecondaryGraphic() !== undefined) {
-            this._currentScreenData.setSecondaryGraphic(show.getSecondaryGraphic());
+            this._currentScreenData.setSecondaryGraphic(this._updatedState.getSecondaryGraphic());
         }
         if (this._currentScreenDataUpdateListener !== null && this._currentScreenDataUpdateListener !== undefined) {
-            this._currentScreenDataUpdateListener(this._currentScreenData);
+            this._currentScreenDataUpdateListener(async function () {
+                return Promise.resolve(this._currentScreenData);
+            });
         }
+    }
+
+    _showRPCSupportsTemplateConfiguration () {
+        if (this._lifecycleManager === null || this._lifecycleManager.getSdlMsgVersion() === null) {
+            return false;
+        }
+        return this._lifecycleManager.getSdlMsgVersion().getMajorVersion() >= 6;
     }
 
     /**
@@ -609,9 +704,9 @@ class _TextAndGraphicUpdateOperation extends _Task {
      * @private
      * @returns {Boolean} - Whether or not the primary image needs to be uploaded.
      */
-    _shouldUpdatePrimaryImage () {
-        const templateSupportsPrimaryArtwork = this._templateSupportsImageField(ImageFieldName.graphic);
-        const currentScreenDataPrimaryGraphicName = (this._currentScreenData !== null && this._currentScreenData !== undefined && this._currentScreenData.getGraphic() !== null && this._currentScreenData.getGraphic() !== undefined) ? this._currentScreenData.getGraphic().getValueParam() : null;
+    _shouldUpdatePrimaryImage () { // If the template is updating, we don't yet know it's capabilities. Just assume the template supports the primary image.
+        const templateSupportsPrimaryArtwork = this._templateSupportsImageField(ImageFieldName.graphic) || this._shouldUpdateTemplateConfig();
+        const currentScreenDataPrimaryGraphicName = (this._currentScreenData !== null && this._currentScreenData !== undefined && this._currentScreenData.getPrimaryGraphic() !== null && this._currentScreenData.getPrimaryGraphic() !== undefined) ? this._currentScreenData.getPrimaryGraphic().getName() : null;
         const primaryGraphicName = (this._updatedState.getPrimaryGraphic() !== null && this._updatedState.getPrimaryGraphic() !== undefined) ? this._updatedState.getPrimaryGraphic().getName() : null;
 
         const graphicMatchesExisting = currentScreenDataPrimaryGraphicName === primaryGraphicName;
@@ -625,14 +720,15 @@ class _TextAndGraphicUpdateOperation extends _Task {
      * @returns {Boolean} - Whether or not the secondary image needs to be uploaded.
      */
     _shouldUpdateSecondaryImage () {
-        const templateSupportsSecondaryArtwork = this._templateSupportsImageField(ImageFieldName.secondaryGraphic);
-        const currentScreenDataSecondaryGraphicName = (this._currentScreenData !== null && this._currentScreenData !== undefined && this._currentScreenData.getSecondaryGraphic() !== null && this._currentScreenData.getSecondaryGraphic() !== undefined) ? this._currentScreenData.getSecondaryGraphic().getValueParam() : null;
+        // If the template is updating, we don't yet know it's capabilities. Just assume the template supports the secondary image.
+        const templateSupportsSecondaryArtwork = this._templateSupportsImageField(ImageFieldName.secondaryGraphic) || this._shouldUpdateTemplateConfig();
+        const currentScreenDataSecondaryGraphicName = (this._currentScreenData !== null && this._currentScreenData !== undefined && this._currentScreenData.getSecondaryGraphic() !== null && this._currentScreenData.getSecondaryGraphic() !== undefined) ? this._currentScreenData.getSecondaryGraphic().getName() : null;
         const secondaryGraphicName = (this._updatedState.getSecondaryGraphic() !== null && this._updatedState.getSecondaryGraphic() !== undefined) ? this._updatedState.getSecondaryGraphic().getName() : null;
 
         const graphicMatchesExisting = currentScreenDataSecondaryGraphicName === secondaryGraphicName;
 
         // Cannot detect if there is a secondary image below v5.0, so we'll just try to detect if the primary image is allowed and allow the secondary image if it is.
-        if (this._lifecycleManager.getSdlMsgVersion().getMajorVersion() >= 5) {
+        if (this._lifecycleManager !== null && this._lifecycleManager.getSdlMsgVersion().getMajorVersion() >= 5) {
             return templateSupportsSecondaryArtwork && !graphicMatchesExisting;
         } else {
             return this._templateSupportsImageField(ImageFieldName.graphic) && !graphicMatchesExisting;
@@ -655,7 +751,8 @@ class _TextAndGraphicUpdateOperation extends _Task {
      * @returns {Boolean} - True if mediaTrackTextField should be updated, false if not
      */
     _shouldUpdateMediaTrackField () {
-        return this._templateSupportsTextField(TextFieldName.mediaTrack);
+        // If the template is updating, we don't yet know it's capabilities. Just assume the template supports the media text field.
+        return this._templateSupportsTextField(TextFieldName.mediaTrack) || this._shouldUpdateTemplateConfig();
     }
 
     /**
@@ -664,7 +761,17 @@ class _TextAndGraphicUpdateOperation extends _Task {
      * @returns {Boolean} - True if title should be updated, false if not
      */
     _shouldUpdateTitleField () {
-        return  this._templateSupportsTextField(TextFieldName.templateTitle);
+        return  this._templateSupportsTextField(TextFieldName.templateTitle) || this._shouldUpdateTemplateConfig();
+    }
+
+    _shouldUpdateTemplateConfig () {
+        if (this._updatedState.getTemplateConfiguration() === null || this._updatedState.getTemplateConfiguration() === undefined) {
+            return false;
+        } else if (this._currentScreenData.getTemplateConfiguration() === null || this._currentScreenData.getTemplateConfiguration() === undefined) {
+            return true;
+        }
+        // TODO: What even am I going to do here
+        return !this._updatedState.getTemplateConfiguration().getParameters() === this._currentScreenData.getTemplateConfiguration().getParameters();
     }
 
     /**
@@ -680,6 +787,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
     /**
      * Return the current screen data
      * @private
+     * @returns {_TextAndGraphicState}
      */
     _getCurrentScreenData () {
         return this._currentScreenData;
@@ -688,7 +796,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
     /**
      * Set the current screen data
      * @private
-     * @param {Show} show - A show of the current screen data
+     * @param {_TextAndGraphicState} show - A show of the current screen data
      */
     _setCurrentScreenData (show) {
         this._currentScreenData = show;

--- a/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
@@ -774,7 +774,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
         } else if (this._currentScreenData.getTemplateConfiguration() === null || this._currentScreenData.getTemplateConfiguration() === undefined) {
             return true;
         }
-        // TODO: What even am I going to do here
+
         return !this._updatedState.getTemplateConfiguration().getParameters() === this._currentScreenData.getTemplateConfiguration().getParameters();
     }
 

--- a/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
@@ -83,7 +83,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
         this._fullShow = this._assembleShowImages(this._fullShow);
         this._fullShow = this._assembleLayout(this._fullShow);
 
-        if (this._showRPCSupportsTemplateConfiguration()) {
+        if (this._showRpcSupportsTemplateConfiguration()) {
             this._updateGraphicsAndShow(this._fullShow);
         } else {
             if (this._shouldUpdateTemplateConfig()) {
@@ -136,11 +136,14 @@ class _TextAndGraphicUpdateOperation extends _Task {
                 this._updateCurrentScreenDataFromShow(show);
             } else {
                 console.info('Text and Graphic Show failed');
+                this._currentScreenDataUpdateListener(() => {
+                    throw new Error('Text and Graphic Show failed');
+                });
             }
             return response.getSuccess();
         } else {
             console.info('LifecycleManager is null, Text and Graphic update failed');
-            this._currentScreenDataUpdateListener(async () => {
+            this._currentScreenDataUpdateListener(() => {
                 throw new Error('LifecycleManager is null, Text and Graphic update failed');
             });
             this._finishOperation(false);
@@ -153,14 +156,20 @@ class _TextAndGraphicUpdateOperation extends _Task {
         if (this._lifecycleManager !== null) {
             const response = await this._lifecycleManager.sendRpcResolve(setLayout);
             if (response.getSuccess()) {
+                console.info('Text and Graphic update complete');
                 this._updateCurrentScreenDataFromSetDisplayLayout(setLayout);
             } else {
                 console.info('Text and Graphic SetDisplayLayout failed');
+                this._currentScreenDataUpdateListener(() => {
+                    throw new Error('Text and Graphic SetDisplayLayout failed');
+                });
             }
             return response.getSuccess();
         } else {
             console.info('LifecycleManager is null, Text and Graphic update failed');
-
+            this._currentScreenDataUpdateListener(() => {
+                throw new Error('LifecycleManager is null, Text and Graphic update failed');
+            });
             this._finishOperation(false);
             return;
         }
@@ -522,7 +531,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
         newShow.setMetadataTags(show.getMetadataTags());
         newShow.setAlignment(show.getAlignment());
 
-        if (this._showRPCSupportsTemplateConfiguration()) {
+        if (this._showRpcSupportsTemplateConfiguration()) {
             newShow.setTemplateConfiguration(show.getTemplateConfiguration());
         }
         return newShow;
@@ -544,19 +553,28 @@ class _TextAndGraphicUpdateOperation extends _Task {
         return show;
     }
 
+    /**
+     * Sets the template configuration information
+     * @param {Show} show - A Show RPC Message.
+     * @returns {Show} - The modified Show RPC Message.
+     */
     _assembleLayout (show) {
-        if (!this._showRPCSupportsTemplateConfiguration() || !this._shouldUpdateTemplateConfig()) {
+        if (!this._showRpcSupportsTemplateConfiguration() || !this._shouldUpdateTemplateConfig()) {
             return show;
         }
         show.setTemplateConfiguration(this._updatedState.getTemplateConfiguration());
         return show;
     }
 
+    /**
+     * Updates the local state to match what was sent
+     * @param {SetDisplayLayout} setDisplayLayout - A SetDisplayLayout RPC Message.
+     */
     _updateCurrentScreenDataFromSetDisplayLayout (setDisplayLayout) {
         this._currentScreenData.setTemplateConfiguration(new TemplateConfiguration().setTemplate(setDisplayLayout.getDisplayLayout()).setDayColorScheme(setDisplayLayout.getDayColorScheme()).setNightColorScheme(setDisplayLayout.getNightColorScheme()));
-        if (this._currentScreenDataUpdateListener !== null) {
-            this._currentScreenDataUpdateListener(async function () {
-                return Promise.resolve(this._currentScreenData);
+        if (typeof this._currentScreenDataUpdateListener === 'function') {
+            this._currentScreenDataUpdateListener(async () => {
+                return this._currentScreenData;
             });
         }
     }
@@ -617,14 +635,14 @@ class _TextAndGraphicUpdateOperation extends _Task {
         if (show.getSecondaryGraphic() !== null && show.getSecondaryGraphic() !== undefined) {
             this._currentScreenData.setSecondaryGraphic(this._updatedState.getSecondaryGraphic());
         }
-        if (this._currentScreenDataUpdateListener !== null && this._currentScreenDataUpdateListener !== undefined) {
-            this._currentScreenDataUpdateListener(async function () {
-                return Promise.resolve(this._currentScreenData);
+        if (typeof this._currentScreenDataUpdateListener === 'function') {
+            this._currentScreenDataUpdateListener(async () => {
+                return this._currentScreenData;
             });
         }
     }
 
-    _showRPCSupportsTemplateConfiguration () {
+    _showRpcSupportsTemplateConfiguration () {
         if (this._lifecycleManager === null || this._lifecycleManager.getSdlMsgVersion() === null) {
             return false;
         }
@@ -775,7 +793,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
             return true;
         }
 
-        return !this._updatedState.getTemplateConfiguration().getParameters() === this._currentScreenData.getTemplateConfiguration().getParameters();
+        return this._updatedState.getTemplateConfiguration().getParameters() !== this._currentScreenData.getTemplateConfiguration().getParameters();
     }
 
     /**

--- a/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
@@ -38,7 +38,6 @@ import { MetadataTags } from '../../rpc/structs/MetadataTags';
 import { TextFieldName } from '../../rpc/enums/TextFieldName';
 import { SetDisplayLayout } from '../../rpc/messages/SetDisplayLayout';
 import { TemplateConfiguration } from '../../rpc/structs/TemplateConfiguration';
-import { _TextAndGraphicState } from './_TextAndGraphicState';
 
 class _TextAndGraphicUpdateOperation extends _Task {
     /**
@@ -333,7 +332,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
         if (this._updatedState.getTextField1() !== null && this._updatedState.getTextField1() !== undefined && this._updatedState.getTextField1().length > 0) {
             tempString = tempString + this._updatedState.getTextField1();
             if (this._updatedState.getTextField1Type() !== null && this._updatedState.getTextField1Type() !== undefined) {
-                tags.setMainField1(this._updatedState.getTextField1Type());
+                tags.setMainField1([this._updatedState.getTextField1Type()]);
             }
         }
 
@@ -342,7 +341,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
                 // text does not exist in slots 3 or 4, put text2 in slot 2
                 show.setMainField2(this._updatedState.getTextField2());
                 if (this._updatedState.getTextField2Type() !== null && this._updatedState.getTextField2Type() !== undefined) {
-                    tags.setMainField2(this._updatedState.getTextField2Type());
+                    tags.setMainField2([this._updatedState.getTextField2Type()]);
                 }
             } else if (this._updatedState.getTextField1() !== null && this._updatedState.getTextField1() !== undefined && this._updatedState.getTextField1().length > 0) {
                 // If text 1 exists, put it in slot 1 formatted
@@ -359,7 +358,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
                 // If text 1 does not exist, put it in slot 1 unformatted
                 tempString = tempString + this._updatedState.getTextField2();
                 if (this._updatedState.getTextField2Type() !== null && this._updatedState.getTextField2Type() !== undefined) {
-                    tags.setMainField1(this._updatedState.getTextField2Type());
+                    tags.setMainField1([this._updatedState.getTextField2Type()]);
                 }
             }
         }
@@ -396,7 +395,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
                 // If text 3 does not exist, put it in slot 3 unformatted
                 tempString = tempString + this._updatedState.getTextField4();
                 if (this._updatedState.getTextField4Type() !== null && this._updatedState.getTextField4Type() !== undefined) {
-                    tags.setMainField2(this._updatedState.getTextField4Type());
+                    tags.setMainField2([this._updatedState.getTextField4Type()]);
                 }
             }
         }
@@ -421,23 +420,23 @@ class _TextAndGraphicUpdateOperation extends _Task {
         if (this._updatedState.getTextField1() !== null && this._updatedState.getTextField1() !== undefined && this._updatedState.getTextField1().length > 0) {
             show.setMainField1(this._updatedState.getTextField1());
             if (this._updatedState.getTextField1Type() !== null && this._updatedState.getTextField1Type() !== undefined) {
-                tags.setMainField1(this._updatedState.getTextField1Type());
+                tags.setMainField1([this._updatedState.getTextField1Type()]);
             }
         }
 
         if (this._updatedState.getTextField2() !== null && this._updatedState.getTextField2() !== undefined && this._updatedState.getTextField2().length > 0) {
             show.setMainField2(this._updatedState.getTextField2());
             if (this._updatedState.getTextField2Type() !== null && this._updatedState.getTextField2Type() !== undefined) {
-                tags.setMainField2(this._updatedState.getTextField2Type());
+                tags.setMainField2([this._updatedState.getTextField2Type()]);
             }
         }
 
         let tempString = '';
 
         if (this._updatedState.getTextField3() !== null && this._updatedState.getTextField3() !== undefined && this._updatedState.getTextField3().length > 0) {
-            tempString.append(this._updatedState.getTextField3());
+            tempString = this._updatedState.getTextField3();
             if (this._updatedState.getTextField3Type() !== null && this._updatedState.getTextField3Type() !== undefined) {
-                tags.setMainField3(this._updatedState.getTextField3Type());
+                tags.setMainField3([this._updatedState.getTextField3Type()]);
             }
         }
 
@@ -457,7 +456,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
                 // If text 3 does not exist, put it in slot 3 formatted
                 tempString = tempString + this._updatedState.getTextField4();
                 if (this._updatedState.getTextField4Type() !== null && this._updatedState.getTextField4Type() !== undefined) {
-                    tags.setMainField3(this._updatedState.getTextField4Type());
+                    tags.setMainField3([this._updatedState.getTextField4Type()]);
                 }
             }
         }
@@ -476,29 +475,29 @@ class _TextAndGraphicUpdateOperation extends _Task {
         const tags = new MetadataTags();
         if (this._updatedState.getTextField1() !== null && this._updatedState.getTextField1() !== undefined && this._updatedState.getTextField1().length > 0) {
             show.setMainField1(this._updatedState.getTextField1());
-            if (this._updatedState.getTextField1Type() !== null) {
-                tags.setMainField1(this._updatedState.getTextField1Type());
+            if (this._updatedState.getTextField1Type() !== null && this._updatedState.getTextField1Type() !== undefined) {
+                tags.setMainField1([this._updatedState.getTextField1Type()]);
             }
         }
 
         if (this._updatedState.getTextField2() !== null && this._updatedState.getTextField2() !== undefined && this._updatedState.getTextField2().length > 0) {
             show.setMainField2(this._updatedState.getTextField2());
-            if (this._updatedState.getTextField2Type() !== null) {
-                tags.setMainField2(this._updatedState.getTextField2Type());
+            if (this._updatedState.getTextField2Type() !== null && this._updatedState.getTextField2Type() !== undefined) {
+                tags.setMainField2([this._updatedState.getTextField2Type()]);
             }
         }
 
         if (this._updatedState.getTextField3() !== null && this._updatedState.getTextField3() !== undefined && this._updatedState.getTextField3().length > 0) {
             show.setMainField3(this._updatedState.getTextField3());
             if (this._updatedState.getTextField3Type() !== null && this._updatedState.getTextField3Type() !== undefined) {
-                tags.setMainField3(this._updatedState.getTextField3Type());
+                tags.setMainField3([this._updatedState.getTextField3Type()]);
             }
         }
 
         if (this._updatedState.getTextField4() !== null && this._updatedState.getTextField4() !== undefined && this._updatedState.getTextField4().length > 0) {
             show.setMainField4(this._updatedState.getTextField4());
             if (this._updatedState.getTextField4Type() !== null && this._updatedState.getTextField4Type() !== undefined) {
-                tags.setMainField4(this._updatedState.getTextField4Type());
+                tags.setMainField4([this._updatedState.getTextField4Type()]);
             }
         }
 
@@ -764,6 +763,11 @@ class _TextAndGraphicUpdateOperation extends _Task {
         return  this._templateSupportsTextField(TextFieldName.templateTitle) || this._shouldUpdateTemplateConfig();
     }
 
+    /**
+     * Check to see if the template config should be updated
+     * @private
+     * @returns {Boolean} - True if templateConfiguration should be updated, false if not
+     */
     _shouldUpdateTemplateConfig () {
         if (this._updatedState.getTemplateConfiguration() === null || this._updatedState.getTemplateConfiguration() === undefined) {
             return false;
@@ -787,7 +791,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
     /**
      * Return the current screen data
      * @private
-     * @returns {_TextAndGraphicState}
+     * @returns {_TextAndGraphicState} - The current screen data
      */
     _getCurrentScreenData () {
         return this._currentScreenData;
@@ -796,7 +800,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
     /**
      * Set the current screen data
      * @private
-     * @param {_TextAndGraphicState} show - A show of the current screen data
+     * @param {_TextAndGraphicState} show - A _TextAndGraphicState of the current screen data
      */
     _setCurrentScreenData (show) {
         this._currentScreenData = show;

--- a/lib/js/src/rpc/enums/FunctionID.js
+++ b/lib/js/src/rpc/enums/FunctionID.js
@@ -744,22 +744,6 @@ class FunctionID extends Enum {
     }
 
     /**
-     * Get the enum value for OnUpdateFile.
-     * @returns {Number} - The enum value.
-     */
-    static get OnUpdateFile () {
-        return FunctionID._MAP.OnUpdateFile;
-    }
-
-    /**
-     * Get the enum value for OnUpdateSubMenu.
-     * @returns {Number} - The enum value.
-     */
-    static get OnUpdateSubMenu () {
-        return FunctionID._MAP.OnUpdateSubMenu;
-    }
-
-    /**
      * Get the enum value for EncodedSyncPData.
      * @returns {Number} - The enum value.
      */

--- a/lib/js/src/rpc/enums/ImageFieldName.js
+++ b/lib/js/src/rpc/enums/ImageFieldName.js
@@ -191,15 +191,6 @@ class ImageFieldName extends Enum {
     }
 
     /**
-     * Get the enum value for subMenuIcon.
-     * The image field for AddSubMenu.menuIcon
-     * @returns {String} - The enum value.
-     */
-    static get subMenuIcon () {
-        return ImageFieldName._MAP.subMenuIcon;
-    }
-
-    /**
      * Get the value for the given enum key
      * @param {*} key - A key to find in the map of the subclass
      * @returns {*} - Returns a value if found, or null if not found
@@ -235,7 +226,6 @@ ImageFieldName._MAP = Object.freeze({
     'alertIcon': 'alertIcon',
     'subMenuIcon': 'subMenuIcon',
     'subtleAlertIcon': 'subtleAlertIcon',
-    'subMenuIcon': 'subMenuIcon',
 });
 
 export { ImageFieldName };


### PR DESCRIPTION
Fixes #175 

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Example code snippet for updating the screen layout from the example apps:
```
await screenManager.changeLayout(
    new SDL.rpc.structs.TemplateConfiguration()
        .setTemplate(SDL.rpc.enums.PredefinedLayout.TEXTBUTTONS_WITH_GRAPHIC)
);
```

### Summary
Adds a new operation to the ScreenManager for changing the HMI TemplateConfiguration.
Also updates the setters in the TextAndGraphicManagerBase to call sdlUpdate instead of update to avoid cases where a task would be added which could not be run because isDirty was never set.