### PR TITLE
Update generator to not strip todos

### DIFF
--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -253,7 +253,7 @@ class InterfaceProducerCommon(ABC):
     @staticmethod
     def extract_description(data, length: int = 2048) -> list:
         """
-        Evaluate, align and delete @TODO
+        Extract description
         :param data: list with description
         :param length:
         :return: evaluated string
@@ -262,7 +262,7 @@ class InterfaceProducerCommon(ABC):
             return []
         if isinstance(data, list):
             data = ' '.join(data)
-        return textwrap.wrap(re.sub(r'(\s{2,}|\n|\[@TODO.+)', ' ', data).strip(), length)
+        return textwrap.wrap(re.sub(r'(\s{2,}|\n)', ' ', data).strip(), length)
 
     def extract_name_description(self, param):
         """


### PR DESCRIPTION
Fixes #324 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Summary
This PR fixes an issue in the RPC Generator where it cuts off the JSdoc comments after TODO

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform) and this pull request adheres to the [Contributing Guide](./CONTRIBUTING.md). 
