### PR TITLE
Add null/undefined check for text alignment

### DIFF
--- a/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
@@ -78,7 +78,12 @@ class _TextAndGraphicUpdateOperation extends _Task {
             this._finishOperation(false);
             return;
         }
-        this._fullShow = new Show().setAlignment(this._updatedState.getTextAlignment());
+        this._fullShow = new Show();
+        if (this._updatedState.getTextAlignment() !== null && this._updatedState.getTextAlignment() !== undefined) {
+            this._fullShow = this._fullShow.setAlignment(this._updatedState.getTextAlignment());
+        }/* else {
+            this._fullShow = this._fullShow.setAlignment(this._currentScreenData.getTextAlignment());
+        }*/
         this._fullShow = this._assembleShowText(this._fullShow);
         this._fullShow = this._assembleShowImages(this._fullShow);
         this._fullShow = this._assembleLayout(this._fullShow);
@@ -529,7 +534,9 @@ class _TextAndGraphicUpdateOperation extends _Task {
         newShow.setMainField4(show.getMainField4());
         newShow.setTemplateTitle(show.getTemplateTitle());
         newShow.setMetadataTags(show.getMetadataTags());
-        newShow.setAlignment(show.getAlignment());
+        if (show.getAlignment() !== null && show.getAlignment() !== undefined) {
+            newShow.setAlignment(show.getAlignment());
+        }
 
         if (this._showRpcSupportsTemplateConfiguration()) {
             newShow.setTemplateConfiguration(show.getTemplateConfiguration());

--- a/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
@@ -81,9 +81,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
         this._fullShow = new Show();
         if (this._updatedState.getTextAlignment() !== null && this._updatedState.getTextAlignment() !== undefined) {
             this._fullShow = this._fullShow.setAlignment(this._updatedState.getTextAlignment());
-        }/* else {
-            this._fullShow = this._fullShow.setAlignment(this._currentScreenData.getTextAlignment());
-        }*/
+        }
         this._fullShow = this._assembleShowText(this._fullShow);
         this._fullShow = this._assembleShowImages(this._fullShow);
         this._fullShow = this._assembleLayout(this._fullShow);


### PR DESCRIPTION
Fixes #326 

This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
Start a TextAndGraphicUpdateOperation without updating the text alignment. Previously it would error, but now it should succeed in the update.

### Summary
Adds a check for the text alignment field in the TextAndGraphicUpdateOperation class