### PR TITLE
Fix failing RPC generator unit tests

### DIFF
--- a/generator/templates/base_struct_function.js
+++ b/generator/templates/base_struct_function.js
@@ -1,7 +1,7 @@
 {% extends 'base_template.js' %}
 
 {% block typedef %}
-{%- if description is defined or deprecated is defined %}
+{%- if description is defined or deprecated is defined and deprecated is not none %}
 /**
  {% if description is defined -%}
  {% for d in description -%}
@@ -10,7 +10,7 @@
  {% else -%}
  * Struct description not available.
  {% endif -%}
- {% if deprecated is defined -%}
+ {% if deprecated is defined and deprecated is not none -%}
  * @deprecated
  {% endif -%}
  */
@@ -76,7 +76,7 @@
 
     /**
      * Get the {{method.method_title}}
-     {% if deprecated is defined -%}
+     {% if deprecated is defined and deprecated is not none -%}
      * @deprecated
      {% endif -%}
      * @returns {{'%s%s%s'|format('{', method.type, '}')}} - the {{method.key}} value

--- a/generator/test/runner.py
+++ b/generator/test/runner.py
@@ -33,7 +33,8 @@ def main():
     suite.addTests(TestLoader().loadTestsFromTestCase(CodeFormatAndQuality))
 
     runner = TextTestRunner(verbosity=2)
-    runner.run(suite)
+    ret = not runner.run(suite).wasSuccessful()
+    sys.exit(ret)
 
 
 if __name__ == '__main__':

--- a/generator/test/test_enums.py
+++ b/generator/test/test_enums.py
@@ -27,14 +27,17 @@ class TestEnumsProducer(TestCase):
         expected['name'] = 'FunctionID'
         expected['imports'] = {self.producer.imports(what='Enum', wherefrom='../../util/Enum.js')}
         expected['methods'] = (self.producer.methods(method_title='RESERVED',
-                                                     description=[], type='Number'),
+                                                     description=[], type='Number', since=None, history=None, deprecated=None),
                                self.producer.methods(method_title='RegisterAppInterface',
-                                                     description=[], type='Number'),
+                                                     description=[], type='Number', since=None, history=None, deprecated=None),
                                self.producer.methods(method_title='PerformAudioPassThru',
-                                                     description=[], type='Number'))
+                                                     description=[], type='Number', since=None, history=None, deprecated=None))
         expected['params'] = (self.producer.params(key='RESERVED', value="'RESERVED'"),
                               self.producer.params(key='RegisterAppInterface', value='0x01'),
                               self.producer.params(key='PerformAudioPassThru', value='0x10'))
+        expected['since'] = None
+        expected['history'] = None
+        expected['deprecated'] = None
         expected['extend'] = 'Enum'
         result = self.producer.transform(item)
         self.assertDictEqual(expected, result)
@@ -49,8 +52,11 @@ class TestEnumsProducer(TestCase):
         expected['file_name'] = 'Result'
         expected['imports'] = {self.producer.imports(what='Enum', wherefrom='../../util/Enum.js')}
         expected['methods'] = (self.producer.methods(method_title='SUCCESS',
-                                                      description=[], type='String'),)
+                                                      description=[], type='String', since=None, history=None, deprecated=None),)
         expected['params'] = (self.producer.params(key='SUCCESS', value="'SUCCESS'"),)
+        expected['since'] = None
+        expected['history'] = None
+        expected['deprecated'] = None
         expected['extend'] = 'Enum'
         result = self.producer.transform(item)
         self.assertDictEqual(expected, result)

--- a/generator/test/test_functions.py
+++ b/generator/test/test_functions.py
@@ -85,22 +85,25 @@ class TestFunctionsProducer(TestCase):
         expected['methods'] = (self.producer.methods(key='KEY_SDL_MSG_VERSION',
                                                      method_title='SdlMsgVersion', external='SdlMsgVersion',
                                                      description=['See SyncMsgVersion'], param_name='version',
-                                                     type='SdlMsgVersion'),
+                                                     type='SdlMsgVersion', param_values={}, since=None, history=None, deprecated=None),
                                self.producer.methods(key='KEY_FULL_APP_ID', method_title='FullAppID',
                                                      external=None, description=['ID used'], param_name='id',
-                                                     type='String'),
+                                                     type='String', param_values={}, since=None, history=None, deprecated=None),
                                self.producer.methods(key='KEY_DAY_COLOR_SCHEME', param_name='scheme',
                                                      method_title='DayColorScheme', external='TemplateColorScheme',
                                                      description=['A color scheme for all display layout templates.'],
-                                                     type='TemplateColorScheme'),
+                                                     type='TemplateColorScheme', param_values={}, since=None, history=None, deprecated=None),
                                self.producer.methods(key='KEY_TTS_NAME', param_name='name',
                                                      method_title='TtsName', external='TTSChunk',
-                                                     description=['TTS string for'], type='TTSChunk[]'))
+                                                     description=['TTS string for'], type='TTSChunk[]', param_values={}, since=None, history=None, deprecated=None))
         expected['params'] = (self.producer.params(key='KEY_SDL_MSG_VERSION', value="'syncMsgVersion'"),
                               self.producer.params(key='KEY_FULL_APP_ID', value="'fullAppID'"),
                               self.producer.params(key='KEY_DAY_COLOR_SCHEME', value="'dayColorScheme'"),
                               self.producer.params(key='KEY_TTS_NAME', value="'ttsName'"),
                               self.producer.params(key='APP_ID_MAX_LENGTH', value=10))
+        expected['since'] = None
+        expected['history'] = None
+        expected['deprecated'] = None
         expected['func'] = 'RegisterAppInterface'
         expected['extend'] = 'RpcRequest'
 
@@ -128,14 +131,17 @@ class TestFunctionsProducer(TestCase):
         expected['methods'] = (self.producer.methods(key='KEY_LANGUAGE',
                                                      method_title='Language', external='Language',
                                                      description=['The currently'], param_name='language',
-                                                     type='Language'),
+                                                     type='Language', param_values={}, since=None, history=None, deprecated=None),
                                self.producer.methods(key='KEY_SUPPORTED_DIAG_MODES',
                                                      method_title='SupportedDiagModes', external=None,
                                                      description=['Specifies the'], param_name='modes',
-                                                     type='Number[]'))
+                                                     type='Number[]', param_values={}, since=None, history=None, deprecated=None))
         expected['params'] = (self.producer.params(key='KEY_LANGUAGE', value="'language'"),
                               self.producer.params(key='KEY_SUPPORTED_DIAG_MODES', value="'supportedDiagModes'"))
         expected['description'] = ['The response']
+        expected['since'] = None
+        expected['history'] = None
+        expected['deprecated'] = None
         expected['func'] = 'RegisterAppInterface'
         expected['extend'] = 'RpcResponse'
         result = self.producer.transform(item)
@@ -151,6 +157,9 @@ class TestFunctionsProducer(TestCase):
                                self.producer.imports(what='FunctionID', wherefrom='../enums/FunctionID.js')}
         expected['methods'] = ()
         expected['params'] = ()
+        expected['since'] = None
+        expected['history'] = None
+        expected['deprecated'] = None
         expected['func'] = 'UnregisterAppInterface'
         expected['extend'] = 'RpcRequest'
         result = self.producer.transform(item)
@@ -173,9 +182,12 @@ class TestFunctionsProducer(TestCase):
         expected['methods'] = (self.producer.methods(key='KEY_FILE_TYPE',
                                                      method_title='FileType', external='FileType',
                                                      description=['Selected file type.'], param_name='type',
-                                                     type='FileType'),)
+                                                     type='FileType', param_values={}, since=None, history=None, deprecated=None),)
         expected['params'] = (self.producer.params(key='KEY_FILE_TYPE', value="'fileType'"),)
         expected['description'] = ['Used to']
+        expected['since'] = None
+        expected['history'] = None
+        expected['deprecated'] = None
         expected['script'] = self.producer.get_file_content('templates/scripts/PutFileRequest.js')
         expected['func'] = 'PutFile'
         expected['extend'] = 'RpcRequest'
@@ -196,9 +208,12 @@ class TestFunctionsProducer(TestCase):
         expected['methods'] = (self.producer.methods(key='KEY_URL',
                                                      method_title='URL', external=None,
                                                      description=['If'], param_name='url',
-                                                     type='String'),)
+                                                     type='String', param_values={}, since=None, history=None, deprecated=None),)
         expected['params'] = (self.producer.params(key='KEY_URL', value="'URL'"),)
         expected['description'] = ['Callback including']
+        expected['since'] = None
+        expected['history'] = None
+        expected['deprecated'] = None
         expected['func'] = 'OnEncodedSyncPData'
         expected['extend'] = 'RpcNotification'
         result = self.producer.transform(item)
@@ -220,9 +235,12 @@ class TestFunctionsProducer(TestCase):
         expected['methods'] = (self.producer.methods(key='KEY_CHOICE_SET',
                                                      method_title='ChoiceSet', external='Choice',
                                                      description=['A choice is an option given to'], param_name='set',
-                                                     type='Choice[]'),)
+                                                     type='Choice[]', param_values={}, since=None, history=None, deprecated=None),)
         expected['params'] = (self.producer.params(key='KEY_CHOICE_SET', value="'choiceSet'"),)
         expected['description'] = ['creates interaction']
+        expected['since'] = None
+        expected['history'] = None
+        expected['deprecated'] = None
         expected['func'] = 'CreateInteractionChoiceSet'
         expected['extend'] = 'RpcRequest'
         result = self.producer.transform(item)

--- a/generator/test/test_structs.py
+++ b/generator/test/test_structs.py
@@ -31,12 +31,15 @@ class TestStructsProducer(TestCase):
         expected['methods'] = (
             self.producer.methods(
                 description=['Optional image'], external='Image', key='KEY_IMAGE', method_title='Image',
-                param_name='image', type='Image'),
+                param_name='image', type='Image', param_values={}, deprecated=None, history=None, since=None),
             self.producer.methods(
                 description=[], external=None, key='KEY_VALUE', method_title='ValueParam',
-                param_name='value', type='String'))
+                param_name='value', type='String', param_values={}, deprecated=None, history=None, since=None))
         expected['params'] = (self.producer.params(key='KEY_IMAGE', value="'image'"),
                               self.producer.params(key='KEY_VALUE', value="'value'"))
+        expected['since'] = None
+        expected['history'] = None
+        expected['deprecated'] = None
         expected['extend'] = 'RpcStruct'
         result = self.producer.transform(item)
         self.assertDictEqual(expected, result)

--- a/generator/transformers/common_producer.py
+++ b/generator/transformers/common_producer.py
@@ -142,12 +142,9 @@ class InterfaceProducerCommon(ABC):
 
         if getattr(item, 'description', None):
             render['description'] = self.extract_description(item.description)
-        if item.deprecated:
-            render['deprecated'] = item.deprecated
-        if item.history:
-            render['history'] = item.history
-        if item.since:
-            render['since'] = item.since
+        render['since'] = item.since
+        render['history'] = item.history
+        render['deprecated'] = item.deprecated
 
         self.custom_mapping(render, item)
 


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **no** API changes.

### Testing Plan
From the generator directory, run `python3 test/runner.py`. There should be no failing tests.

### Summary
Some of the unit tests for the RPC generator were failing. This PR fixes the failing tests, without changing the generator itself or any of the generated files.