### PR TITLE
Add countRate to SetMediaClockTimer

### DIFF
--- a/lib/js/src/rpc/messages/SetMediaClockTimer.js
+++ b/lib/js/src/rpc/messages/SetMediaClockTimer.js
@@ -129,11 +129,32 @@ class SetMediaClockTimer extends RpcRequest {
     getAudioStreamingIndicator () {
         return this.getObject(AudioStreamingIndicator, SetMediaClockTimer.KEY_AUDIO_STREAMING_INDICATOR);
     }
+
+    /**
+     * Set the CountRate
+     * @since SmartDeviceLink 7.1.0
+     * @param {Number} rate - The value of this parameter is the amount that the media clock timer will advance per 1.0 seconds of real time. Values less than 1.0 will therefore advance the timer slower than real-time, while values greater than 1.0 will advance the timer faster than real-time. e.g. If this parameter is set to `0.5`, the timer will advance one second per two seconds real-time, or at 50% speed. If this parameter is set to `2.0`, the timer will advance two seconds per one second real-time, or at 200% speed. - The desired CountRate.
+     * {'num_min_value': 0.1, 'num_max_value': 100.0}
+     * @returns {SetMediaClockTimer} - The class instance for method chaining.
+     */
+    setCountRate (rate) {
+        this.setParameter(SetMediaClockTimer.KEY_COUNT_RATE, rate);
+        return this;
+    }
+
+    /**
+     * Get the CountRate
+     * @returns {Number} - the KEY_COUNT_RATE value
+     */
+    getCountRate () {
+        return this.getParameter(SetMediaClockTimer.KEY_COUNT_RATE);
+    }
 }
 
 SetMediaClockTimer.KEY_START_TIME = 'startTime';
 SetMediaClockTimer.KEY_END_TIME = 'endTime';
 SetMediaClockTimer.KEY_UPDATE_MODE = 'updateMode';
 SetMediaClockTimer.KEY_AUDIO_STREAMING_INDICATOR = 'audioStreamingIndicator';
+SetMediaClockTimer.KEY_COUNT_RATE = 'countRate';
 
 export { SetMediaClockTimer };


### PR DESCRIPTION
Fixes #347 

This PR is ready for review. The equivalent RPC spec PR should be approved before this PR should be merged: https://github.com/smartdevicelink/rpc_spec/pull/294

### Risk
This PR makes minor API changes.

### Summary
Updates SetMediaClockTimer to include the count rate.