### PR TITLE
SDL 0274: Add preferred FPS to VideoStreamingCapability

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lib/rpc_spec"]
 	path = lib/rpc_spec
-	url = https://github.com/smartdevicelink/rpc_spec.git
-	branch = master
+	url = https://github.com/shiniwat/rpc_spec.git
+	branch = feature/issue-222

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "lib/rpc_spec"]
 	path = lib/rpc_spec
-	url = https://github.com/shiniwat/rpc_spec.git
-	branch = feature/issue-222
+	url = https://github.com/smartdevicelink/rpc_spec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lib/rpc_spec"]
 	path = lib/rpc_spec
 	url = https://github.com/smartdevicelink/rpc_spec.git
+	branch = master

--- a/lib/js/src/rpc/structs/VideoStreamingCapability.js
+++ b/lib/js/src/rpc/structs/VideoStreamingCapability.js
@@ -183,6 +183,25 @@ class VideoStreamingCapability extends RpcStruct {
     getScale () {
         return this.getParameter(VideoStreamingCapability.KEY_SCALE);
     }
+
+    /**
+     * Set the PreferredFPS
+     * @param {Number} fps - The preferred frame rate per second of the head unit. The mobile application / app library may take other factors into account that constrain the frame rate lower than this value, but it should not perform streaming at a higher frame rate than this value. - The desired PreferredFPS.
+     * {'num_min_value': 0, 'num_max_value': 2147483647}
+     * @returns {VideoStreamingCapability} - The class instance for method chaining.
+     */
+    setPreferredFPS (fps) {
+        this.setParameter(VideoStreamingCapability.KEY_PREFERRED_FPS, fps);
+        return this;
+    }
+
+    /**
+     * Get the PreferredFPS
+     * @returns {Number} - the KEY_PREFERRED_FPS value
+     */
+    getPreferredFPS () {
+        return this.getParameter(VideoStreamingCapability.KEY_PREFERRED_FPS);
+    }
 }
 
 VideoStreamingCapability.KEY_PREFERRED_RESOLUTION = 'preferredResolution';
@@ -192,5 +211,6 @@ VideoStreamingCapability.KEY_HAPTIC_SPATIAL_DATA_SUPPORTED = 'hapticSpatialDataS
 VideoStreamingCapability.KEY_DIAGONAL_SCREEN_SIZE = 'diagonalScreenSize';
 VideoStreamingCapability.KEY_PIXEL_PER_INCH = 'pixelPerInch';
 VideoStreamingCapability.KEY_SCALE = 'scale';
+VideoStreamingCapability.KEY_PREFERRED_FPS = 'preferredFPS';
 
 export { VideoStreamingCapability };

--- a/lib/js/src/streaming/video/_VideoStreamingParameters.js
+++ b/lib/js/src/streaming/video/_VideoStreamingParameters.js
@@ -105,7 +105,7 @@ class _VideoStreamingParameters {
             this._format = formats[0];
         }
         const fps = capability.getPreferredFPS();
-        if (fps != null) {
+        if (fps !== null) {
             this._frameRate = fps;
         }
     }

--- a/lib/js/src/streaming/video/_VideoStreamingParameters.js
+++ b/lib/js/src/streaming/video/_VideoStreamingParameters.js
@@ -104,6 +104,10 @@ class _VideoStreamingParameters {
         if (formats !== null && formats.length > 0) {
             this._format = formats[0];
         }
+        const fps = capability.getPreferredFPS();
+        if (fps != null) {
+            this._frameRate = fps;
+        }
     }
 
     /**

--- a/tests/node/streaming/video/VideoStreamingParametersTest.js
+++ b/tests/node/streaming/video/VideoStreamingParametersTest.js
@@ -94,6 +94,7 @@ describe('VideoStreamingParametersTest', function () {
         capability.setPreferredFPS(15);
         params.update(capability);
         Validator.assertEquals(params.getFormat(), format);
+        Validator.assertEquals(params.getFrameRate(), 15);
 
         done();
     });

--- a/tests/node/streaming/video/VideoStreamingParametersTest.js
+++ b/tests/node/streaming/video/VideoStreamingParametersTest.js
@@ -91,6 +91,7 @@ describe('VideoStreamingParametersTest', function () {
 
         format = new VideoStreamingFormat(VideoStreamingProtocol.RTP, VideoStreamingCodec.H264);
         capability.setSupportedFormats([format]);
+        capability.setPreferredFPS(15);
         params.update(capability);
         Validator.assertEquals(params.getFormat(), format);
 


### PR DESCRIPTION
Fixes #115

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
VideoStreamingParametersTest will partially cover this change.

### Summary
Implementing SDL 0274: Add preferred FPS to VideoStreamingCapability.

### Changelog
##### Breaking Changes
* N/A

##### Enhancements
* Adding preferredFPS into VideoStreamingCapability.

##### Bug Fixes
* N/A

### Tasks Remaining:
- N/A

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform) and this pull request adheres to the [Contributing Guide](./CONTRIBUTING.md). 
