### PR TITLE
Do not import a file that leads to the same file

### DIFF
--- a/generator/templates/base_template.js
+++ b/generator/templates/base_template.js
@@ -32,7 +32,9 @@
 */
 {% block imports -%}
 {% for _import in imports|sort %}
+{%- if _import.what != name %}
 import {{'%s %s %s'|format('{', _import.what, '}')}} from '{{_import.wherefrom}}';
+{%- endif -%}
 {%- endfor %}
 {% endblock -%}
 {% block typedef -%}{%- endblock %}


### PR DESCRIPTION
Fixes #372 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
N/A

#### Core Tests
N/A

### Summary
Adds a check to the generator to make sure not to import a file into the same file for the RPC classes.