### PR TITLE
Update RPC version to 7.1.0

### DIFF
--- a/lib/js/src/manager/lifecycle/_LifecycleManager.js
+++ b/lib/js/src/manager/lifecycle/_LifecycleManager.js
@@ -503,7 +503,7 @@ class _LifecycleManager {
     }
 }
 
-_LifecycleManager.MAX_RPC_VERSION = new Version(7, 0, 0);
+_LifecycleManager.MAX_RPC_VERSION = new Version(7, 1, 0);
 _LifecycleManager.REGISTER_APP_INTERFACE_CORRELATION_ID = 65529;
 _LifecycleManager.UNREGISTER_APP_INTERFACE_CORRELATION_ID = 65530;
 


### PR DESCRIPTION
Fixes #375 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
_LifecycleManager.MAX_RPC_VERSION is updated to 7.1.0. No additional tests or changes needed.