### PR TITLE
Include missing deprecation tags

### DIFF
--- a/lib/js/src/rpc/enums/TextFieldName.js
+++ b/lib/js/src/rpc/enums/TextFieldName.js
@@ -94,6 +94,8 @@ class TextFieldName extends Enum {
 
     /**
      * Get the enum value for mediaClock.
+     * @since SmartDeviceLink 1.0.0
+     * @deprecated in SmartDeviceLink 7.1.0
      * Text value for MediaClock field; applies to "Show"
      * @returns {String} - The enum value.
      */

--- a/lib/js/src/rpc/messages/Show.js
+++ b/lib/js/src/rpc/messages/Show.js
@@ -177,6 +177,7 @@ class Show extends RpcRequest {
     /**
      * Set the MediaClock
      * @since SmartDeviceLink 1.0.0
+     * @deprecated in SmartDeviceLink 7.1.0
      * @param {String} clock - Text value for MediaClock field. Has to be properly formatted by Mobile App according to the module's capabilities. If this text is set, any automatic media clock updates previously set with SetMediaClockTimer will be stopped. - The desired MediaClock.
      * {'string_min_length': 0, 'string_max_length': 500}
      * @returns {Show} - The class instance for method chaining.


### PR DESCRIPTION
Fixes the rpc_spec issue brought up in https://github.com/smartdevicelink/rpc_spec/issues/276

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR (Requires seat occupancy rpc_spec PR to be merged in to pass).
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Runs the generated fix made by this rpc_spec PR: https://github.com/smartdevicelink/rpc_spec/issues/276
Show.setMediaClock is now deprecated
TextFieldName.mediaClock is now deprecated
