### PR TITLE
Fix RAI appInfo since attribute

### DIFF
--- a/lib/js/src/rpc/messages/RegisterAppInterface.js
+++ b/lib/js/src/rpc/messages/RegisterAppInterface.js
@@ -352,7 +352,7 @@ class RegisterAppInterface extends RpcRequest {
 
     /**
      * Set the AppInfo
-     * @since SmartDeviceLink 2.0.0
+     * @since SmartDeviceLink 4.2.0
      * @param {AppInfo} info - See AppInfo. - The desired AppInfo.
      * @returns {RegisterAppInterface} - The class instance for method chaining.
      */


### PR DESCRIPTION
Fixes the rpc_spec issue brought up in https://github.com/smartdevicelink/rpc_spec/issues/206

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR (Requires seat occupancy rpc_spec PR to be merged in to pass).
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Runs the generated fix made by this rpc_spec PR: https://github.com/smartdevicelink/rpc_spec/pull/311
RegisterAppInterface.AppInfo now shows 4.2.0 as the correct version it was introduced.
