### PR TITLE
Deprecate SyncPData functions

### DIFF
--- a/lib/js/src/rpc/messages/EncodedSyncPData.js
+++ b/lib/js/src/rpc/messages/EncodedSyncPData.js
@@ -36,6 +36,7 @@ import { RpcRequest } from '../RpcRequest.js';
 
 /**
  * Allows encoded data in the form of SyncP packets to be sent to the SYNC module. Legacy / v1 Protocol implementation; use SyncPData instead. *** DEPRECATED ***
+ * @deprecated
  */
 class EncodedSyncPData extends RpcRequest {
     /**
@@ -43,6 +44,7 @@ class EncodedSyncPData extends RpcRequest {
      * @class
      * @param {object} parameters - An object map of parameters.
      * @since SmartDeviceLink 1.0.0
+     * @deprecated in SmartDeviceLink 7.1.0
      */
     constructor (parameters) {
         super(parameters);

--- a/lib/js/src/rpc/messages/EncodedSyncPDataResponse.js
+++ b/lib/js/src/rpc/messages/EncodedSyncPDataResponse.js
@@ -34,12 +34,17 @@
 import { FunctionID } from '../enums/FunctionID.js';
 import { RpcResponse } from '../RpcResponse.js';
 
+/**
+ * Struct description not available.
+ * @deprecated
+ */
 class EncodedSyncPDataResponse extends RpcResponse {
     /**
      * Initalizes an instance of EncodedSyncPDataResponse.
      * @class
      * @param {object} parameters - An object map of parameters.
      * @since SmartDeviceLink 1.0.0
+     * @deprecated in SmartDeviceLink 7.1.0
      */
     constructor (parameters) {
         super(parameters);

--- a/lib/js/src/rpc/messages/OnEncodedSyncPData.js
+++ b/lib/js/src/rpc/messages/OnEncodedSyncPData.js
@@ -36,6 +36,7 @@ import { RpcNotification } from '../RpcNotification.js';
 
 /**
  * Callback including encoded data of any SyncP packets that SYNC needs to send back to the mobile device. Legacy / v1 Protocol implementation; responds to EncodedSyncPData. *** DEPRECATED ***
+ * @deprecated
  */
 class OnEncodedSyncPData extends RpcNotification {
     /**
@@ -43,6 +44,7 @@ class OnEncodedSyncPData extends RpcNotification {
      * @class
      * @param {object} parameters - An object map of parameters.
      * @since SmartDeviceLink 1.0.0
+     * @deprecated in SmartDeviceLink 7.1.0
      */
     constructor (parameters) {
         super(parameters);


### PR DESCRIPTION
Fixes the rpc_spec issue brought up in https://github.com/smartdevicelink/rpc_spec/issues/237

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR (Requires seat occupancy rpc_spec PR to be merged in to pass).
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Runs the generated fix made by this rpc_spec PR: https://github.com/smartdevicelink/rpc_spec/pull/310
EncodedSyncPData, EncodedSyncPDataResponse, and OnEncodedSyncPData are now deprecated.