### PR TITLE
Align getter and setter rules in generator

### DIFF
--- a/generator/templates/base_struct_function.js
+++ b/generator/templates/base_struct_function.js
@@ -76,8 +76,9 @@
 
     /**
      * Get the {{method.method_title}}
-     {% if deprecated is defined and deprecated is not none -%}
-     * @deprecated
+     {% if method.deprecated is defined and method.deprecated is not none -%}
+     * @since SmartDeviceLink {{method.history[0].since}}
+     * @deprecated in SmartDeviceLink {{method.since}}
      {% endif -%}
      * @returns {{'%s%s%s'|format('{', method.type, '}')}} - the {{method.key}} value
      */


### PR DESCRIPTION
Fixes #380 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have run the unit tests with this PR (Requires seat occupancy rpc_spec PR to be merged in to pass).
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Adds since and additional deprecation information to the getter methods. Also corrects an issue where getter methods were tagged as deprecated because of the class being deprecated, and not because the method itself was deprecated.