### PR TITLE
Fix SdlProtocolBase setting wrong protocol version

### DIFF
--- a/lib/js/src/protocol/_SdlProtocolBase.js
+++ b/lib/js/src/protocol/_SdlProtocolBase.js
@@ -293,7 +293,6 @@ class _SdlProtocolBase {
     _handlePacketReceived (sdlPacket) {
         if (this._protocolVersion === null || this._protocolVersion.getMajor() === 1) {
             this._setVersion(sdlPacket.getVersion());
-            console.log('version', this._protocolVersion);
         }
         const frameType = sdlPacket.getFrameType();
         if (frameType === _FrameType.CONTROL) {

--- a/lib/js/src/protocol/_SdlProtocolBase.js
+++ b/lib/js/src/protocol/_SdlProtocolBase.js
@@ -216,27 +216,27 @@ class _SdlProtocolBase {
      */
     _setVersion (version) {
         if (version > 5) {
-            this._protocolVersion = new Version('5.1.0'); // protect for future, proxy only supports v5 or lower
+            this._protocolVersion = new Version(5, 0, 0); // protect for future, proxy only supports v5 or lower
             this.headerSize = this.constructor.V2_HEADER_SIZE;
             this._mtus[_ServiceType.RPC] = this.constructor.V3_V4_MTU_SIZE;
         } else if (version === 5) {
-            this._protocolVersion = new Version('5.0.0');
+            this._protocolVersion = new Version(5, 0, 0);
             this.headerSize = this.constructor.V2_HEADER_SIZE;
             this._mtus[_ServiceType.RPC] = this.constructor.V3_V4_MTU_SIZE;
         } else if (version === 4) {
-            this._protocolVersion = new Version('4.0.0');
+            this._protocolVersion = new Version(4, 0, 0);
             this.headerSize = this.constructor.V2_HEADER_SIZE;
             this._mtus[_ServiceType.RPC] = this.constructor.V3_V4_MTU_SIZE; // versions 4 supports 128k MTU
         } else if (version === 3) {
-            this._protocolVersion = new Version('3.0.0');
+            this._protocolVersion = new Version(3, 0, 0);
             this.headerSize = this.constructor.V2_HEADER_SIZE;
             this._mtus[_ServiceType.RPC] = this.constructor.V3_V4_MTU_SIZE; // versions 3 supports 128k MTU
         } else if (version === 2) {
-            this._protocolVersion = new Version('2.0.0');
+            this._protocolVersion = new Version(2, 0, 0);
             this.headerSize = this.constructor.V2_HEADER_SIZE;
             this._mtus[_ServiceType.RPC] = this.constructor.V1_V2_MTU_SIZE - this.headerSize;
         } else if (version === 1) {
-            this._protocolVersion = new Version('1.0.0');
+            this._protocolVersion = new Version(1, 0, 0);
             this.headerSize = this.constructor.V1_HEADER_SIZE;
             this._mtus[_ServiceType.RPC] = this.constructor.V1_V2_MTU_SIZE - this.headerSize;
         }
@@ -293,6 +293,7 @@ class _SdlProtocolBase {
     _handlePacketReceived (sdlPacket) {
         if (this._protocolVersion === null || this._protocolVersion.getMajor() === 1) {
             this._setVersion(sdlPacket.getVersion());
+            console.log('version', this._protocolVersion);
         }
         const frameType = sdlPacket.getFrameType();
         if (frameType === _FrameType.CONTROL) {


### PR DESCRIPTION
Fixes #387 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

##### Bug Fixes
* The SdlProtocolBase will no longer attempt to incorrectly set the protocol version to v5.1 when the major version of the first packet header is `> 5`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
