### PR TITLE
Perform null checks for setting image and text fields

### DIFF
--- a/lib/js/src/manager/SystemCapabilityManager.js
+++ b/lib/js/src/manager/SystemCapabilityManager.js
@@ -726,8 +726,12 @@ class SystemCapabilityManager extends _SubManagerBase {
         const convertedCapabilities = new DisplayCapabilities();
         convertedCapabilities.setDisplayType(DisplayType.SDL_GENERIC); // deprecated but it is mandatory...
         convertedCapabilities.setDisplayName(displayName);
-        convertedCapabilities.setTextFields(defaultMainWindow.getTextFields());
-        convertedCapabilities.setImageFields(defaultMainWindow.getImageFields());
+        if (defaultMainWindow.getTextFields() !== null && defaultMainWindow.getTextFields() !== undefined) {
+            convertedCapabilities.setTextFields(defaultMainWindow.getTextFields());
+        }
+        if (defaultMainWindow.getImageFields() !== null && defaultMainWindow.getImageFields() !== undefined) {
+            convertedCapabilities.setImageFields(defaultMainWindow.getImageFields());
+        }
         convertedCapabilities.setTemplatesAvailable(defaultMainWindow.getTemplatesAvailable());
         convertedCapabilities.setNumCustomPresetsAvailable(defaultMainWindow.getNumCustomPresetsAvailable());
         convertedCapabilities.setMediaClockFormats([]); // mandatory field but allows empty array


### PR DESCRIPTION
Fixes #389 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Adds null checks before attempt to set arrays for the DisplayCapability in the SCM.