### PR TITLE
Update RpcStruct._validateType to not throw error for a null value

### DIFF
--- a/lib/js/src/rpc/RpcStruct.js
+++ b/lib/js/src/rpc/RpcStruct.js
@@ -130,19 +130,21 @@ class RpcStruct {
      * @param {Boolean} isArray - Whether or not the given variable is an array to be iterated through.
      */
     _validateType (tClass, obj, isArray = false) {
-        if (isArray) {
-            if (!Array.isArray(obj)) {
-                throw new Error(`${obj.name} must be an array containing items of type ${tClass.name}`);
-            } else {
-                for (const item of obj) {
-                    this._validateType(tClass, item, false);
+        if (obj !== null) {
+            if (isArray) {
+                if (!Array.isArray(obj)) {
+                    throw new Error(`${obj.name} must be an array containing items of type ${tClass.name}`);
+                } else {
+                    for (const item of obj) {
+                        this._validateType(tClass, item, false);
+                    }
                 }
+            } else if (
+                (tClass.prototype instanceof Enum && tClass.keyForValue(obj) === null)
+                || (tClass.prototype instanceof RpcStruct && obj.constructor !== tClass)
+            ) {
+                throw new Error(`${obj.name} must be of type ${tClass.name}`);
             }
-        } else if (
-            (tClass.prototype instanceof Enum && tClass.keyForValue(obj) === null)
-            || (tClass.prototype instanceof RpcStruct && obj !== null && obj.constructor !== tClass)
-        ) {
-            throw new Error(`${obj.name} must be of type ${tClass.name}`);
         }
     }
 }


### PR DESCRIPTION
Fixes #385 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Fixes the case where setting a Struct, Enum, or Array property of an RPC to null would throw an error. These properties can now be set to null, since the marshaller already ignores null/undefined properties.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
