### PR TITLE
Fix setting choice set timeouts

### DIFF
--- a/lib/js/src/manager/screen/choiceset/ChoiceSet.js
+++ b/lib/js/src/manager/screen/choiceset/ChoiceSet.js
@@ -37,10 +37,10 @@ class ChoiceSet {
     /**
      * Create a new instance of ChoiceSet
      * Initialize with a title, choices, and listener. It will use the default timeout and layout, all other properties (such as prompts) will be null.
-     * WARNING: If you display multiple cells with the same title with the only uniquing property between cells being different `vrCommands` or a feature 
-     * that is not displayed on the head unit (e.g. if the head unit doesn't display `secondaryArtwork` and that's the only uniquing property between two cells) 
+     * WARNING: If you display multiple cells with the same title with the only uniquing property between cells being different `vrCommands` or a feature
+     * that is not displayed on the head unit (e.g. if the head unit doesn't display `secondaryArtwork` and that's the only uniquing property between two cells)
      * then the cells may appear to be the same to the user in `Manual` mode. This only applies to RPC connections >= 7.1.0.
-     * WARNING: On < 7.1.0 connections, the title cell will be automatically modified among cells that have the same title when they are preloaded, so they will 
+     * WARNING: On < 7.1.0 connections, the title cell will be automatically modified among cells that have the same title when they are preloaded, so they will
      * always appear differently on-screen when they are displayed. Unique text will be created by appending " (2)", " (3)", etc.
      * @class
      * @param {String} title - The choice set's title
@@ -54,7 +54,11 @@ class ChoiceSet {
         // defaults
         this._defaultLayout = ChoiceSetLayout.CHOICE_SET_LAYOUT_LIST;
         this._layout = this._defaultLayout;
-        this._timeout = 10;
+        this._defaultTimeout = 10;
+        this._TIMEOUT_DEFAULT = 0;
+        this._TIMEOUT_MIN_CAP = 5;
+        this._TIMEOUT_MAX_CAP = 100;
+        this._timeout = this._TIMEOUT_DEFAULT;
 
         this._initialPrompt = null;
         this._timeoutPrompt = null;
@@ -83,11 +87,6 @@ class ChoiceSet {
         if (this.getTitle() !== null) {
             if (this.getTitle().length === 0 || this.getTitle().length > 500) {
                 console.warn(`ChoiceSet: Attempted to create a choice set with a title of ${this.getTitle().length} length. Only 1 - 500 characters are supported.`);
-            }
-        }
-        if (this.getTimeout() !== null) {
-            if (this.getTimeout() < 5 || this.getTimeout() > 100) {
-                console.warn(`ChoiceSet: Attempted to create a choice set with a ${this.getTimeout()} second timeout; Only 5 - 100 seconds is valid`);
             }
         }
         if (this.getChoices() !== null) {
@@ -245,22 +244,57 @@ class ChoiceSet {
 
     /**
      * Get the state timeout
-     * @returns {Number} - The timeout
+     * @returns {Number} - The timeout of a touch interaction in seconds (Manual/touch only)
      */
     getTimeout () {
+        if (this._timeout === this._TIMEOUT_DEFAULT) {
+            return this.getDefaultTimeout();
+        } else if (this._timeout < this._TIMEOUT_MIN_CAP) {
+            return this._TIMEOUT_MIN_CAP;
+        } else if (this._timeout > this._TIMEOUT_MAX_CAP) {
+            return this._TIMEOUT_MAX_CAP;
+        }
         return this._timeout;
     }
 
     /**
      * Set the state timeout
-     * Maps to PerformInteraction.timeout. This applies only to a manual selection (not a voice
-     * selection, which has its timeout handled by the system). Defaults to `defaultTimeout`.
-     * @param {Number} timeout - The timeout
+     * Maps to PerformInteraction.timeout. Timeout in seconds. Defaults to 0, which will use `defaultTimeout`. If this is set below the minimum, it will be capped at 5 seconds. Minimum 5 seconds, maximum 100 seconds. If this is set above the maximum, it will be capped at 100 seconds. Defaults to 0.
+     * This applies only to a manual selection (not a voice selection, which has its timeout handled by the system).
+     * @param {Number} timeout - The timeout of a touch interaction in seconds (Manual/touch only)
      * @returns {ChoiceSet} - A reference to this instance to support method chaining
      */
     setTimeout (timeout) {
         this._timeout = timeout;
         this._checkChoiceSetParameters();
+        return this;
+    }
+
+    /**
+     * Get the state default timeout
+     * @returns {Number} - The default timeout
+     */
+    getDefaultTimeout () {
+        if (this._defaultTimeout < this._TIMEOUT_MIN_CAP) {
+            return this._TIMEOUT_MIN_CAP;
+        } else if (this._defaultTimeout > this._TIMEOUT_MAX_CAP) {
+            return this._TIMEOUT_MAX_CAP;
+        }
+
+        return this._defaultTimeout;
+    }
+
+    /**
+     * Set the state default timeout
+     * Set this to change the default timeout for all choice sets. If a timeout is not set on an individual choice set object
+     * (or if it is set to 0.0), then it will use this timeout instead. See `timeout` for more details.
+     * If this is not set by you, it will default to 10 seconds. The minimum is 5 seconds, the maximum is 100 seconds.
+     * If this is set below the minimum, it will be capped at 5 seconds. If this is set above the maximum, it will be capped at 100 seconds.
+     * @param {Number} defaultTimeout - The default timeout
+     * @returns {ChoiceSet} - A reference to this instance to support method chaining
+     */
+    setDefaultTimeout (defaultTimeout) {
+        this._defaultTimeout = defaultTimeout;
         return this;
     }
 

--- a/lib/js/src/manager/screen/utils/AlertView.js
+++ b/lib/js/src/manager/screen/utils/AlertView.js
@@ -242,8 +242,6 @@ class AlertView {
     getTimeout () {
         if (this._timeout === AlertView._TIMEOUT_DEFAULT) {
             this._timeout = this.getDefaultTimeout();
-        } else if (this._timeout === AlertView._DEFAULT_TIMEOUT) {
-            return AlertView._DEFAULT_TIMEOUT;
         } else if (this._timeout < AlertView._TIMEOUT_MIN) {
             return AlertView._TIMEOUT_MIN;
         } else if (this._timeout > AlertView._TIMEOUT_MAX) {

--- a/lib/js/src/manager/screen/utils/AlertView.js
+++ b/lib/js/src/manager/screen/utils/AlertView.js
@@ -41,7 +41,7 @@ class AlertView {
         this._text = null;
         this._secondaryText = null;
         this._tertiaryText = null;
-        this._timeout = null;
+        this._timeout = AlertView._TIMEOUT_DEFAULT;
         this._audio = null;
         this._showWaitIndicator = false;
         this._softButtons = [];
@@ -197,10 +197,15 @@ class AlertView {
 
     /**
      * Get the Timeout
-     * @returns {Number} - the _defaultTimeout value
+     * @returns {Number} - the AlertView._DEFAULT_TIMEOUT value
      */
     getDefaultTimeout () {
-        return AlertView._defaultTimeout;
+        if (AlertView._DEFAULT_TIMEOUT < AlertView._TIMEOUT_MIN) {
+            return AlertView._TIMEOUT_MIN;
+        } else if (AlertView._DEFAULT_TIMEOUT > AlertView._TIMEOUT_MAX) {
+            return AlertView._TIMEOUT_MAX;
+        }
+        return AlertView._DEFAULT_TIMEOUT;
     }
 
     /**
@@ -214,14 +219,7 @@ class AlertView {
      * @returns {AlertView} - A reference to this instance to support method chaining.
      */
     setDefaultTimeout (defaultTimeout) {
-        if (defaultTimeout <= TIMEOUT_MIN) {
-            AlertView._defaultTimeout = TIMEOUT_MIN;
-            return this;
-        } else if (defaultTimeout >= TIMEOUT_MAX) {
-            AlertView._defaultTimeout = TIMEOUT_MAX;
-            return this;
-        }
-        AlertView._defaultTimeout = defaultTimeout;
+        AlertView._DEFAULT_TIMEOUT = defaultTimeout;
         return this;
     }
 
@@ -242,14 +240,14 @@ class AlertView {
      * @returns {Number} - the timeout value
      */
     getTimeout () {
-        if (this._timeout === null || this._timeout === undefined) {
-            this._timeout = AlertView._defaultTimeout;
-        } else if (this._timeout === AlertView._defaultTimeout) {
-            return AlertView._defaultTimeout;
-        } else if (this._timeout < TIMEOUT_MIN) {
-            return TIMEOUT_MIN;
-        } else if (this._timeout > TIMEOUT_MAX) {
-            return TIMEOUT_MAX;
+        if (this._timeout === AlertView._TIMEOUT_DEFAULT) {
+            this._timeout = this.getDefaultTimeout();
+        } else if (this._timeout === AlertView._DEFAULT_TIMEOUT) {
+            return AlertView._DEFAULT_TIMEOUT;
+        } else if (this._timeout < AlertView._TIMEOUT_MIN) {
+            return AlertView._TIMEOUT_MIN;
+        } else if (this._timeout > AlertView._TIMEOUT_MAX) {
+            return AlertView._TIMEOUT_MAX;
         }
         return this._timeout;
     }
@@ -304,8 +302,9 @@ class AlertView {
     }
 }
 
-AlertView._defaultTimeout = 5;
-const TIMEOUT_MIN = 3;
-const TIMEOUT_MAX = 10;
+AlertView._TIMEOUT_DEFAULT = 0;
+AlertView._DEFAULT_TIMEOUT = 5;
+AlertView._TIMEOUT_MIN = 3;
+AlertView._TIMEOUT_MAX = 10;
 
 export { AlertView };

--- a/tests/managers/screen/AlertViewTests.js
+++ b/tests/managers/screen/AlertViewTests.js
@@ -96,5 +96,90 @@ module.exports = function (appClient) {
 
             done();
         });
+
+        it('testReturnDefaultTimeoutForUnsetTimeout', function () {
+            const alertView = new SDL.manager.screen.utils.AlertView();
+            const testDefaultTimeout = 6;
+            alertView.setDefaultTimeout(testDefaultTimeout);
+
+            Validator.assertEquals(alertView.getDefaultTimeout(), testDefaultTimeout);
+            Validator.assertEquals(alertView.getTimeout(), testDefaultTimeout);
+        });
+
+        it('testReturnDefaultTimeoutForSetTimeout', function () {
+            const alertView = new SDL.manager.screen.utils.AlertView();
+            const testTimeout = 7;
+            const testDefaultTimeout = 9;
+            alertView.setDefaultTimeout(testDefaultTimeout);
+            alertView.setTimeout(testTimeout);
+
+            Validator.assertEquals(alertView.getDefaultTimeout(), testDefaultTimeout);
+            Validator.assertEquals(alertView.getTimeout(), testTimeout);
+        });
+
+        it('testReturnDefaultMaxTimeout', function () {
+            const alertView = new SDL.manager.screen.utils.AlertView();
+            const testDefaultTimeout = 155;
+            alertView.setDefaultTimeout(testDefaultTimeout);
+
+            Validator.assertEquals(alertView.getDefaultTimeout(), SDL.manager.screen.utils.AlertView._TIMEOUT_MAX);
+            Validator.assertEquals(alertView.getTimeout(), SDL.manager.screen.utils.AlertView._TIMEOUT_MAX);
+        });
+
+        it('testReturnDefaultMinTimeout', function () {
+            const alertView = new SDL.manager.screen.utils.AlertView();
+            const testDefaultTimeout = -3;
+            alertView.setDefaultTimeout(testDefaultTimeout);
+
+            Validator.assertEquals(alertView.getDefaultTimeout(), SDL.manager.screen.utils.AlertView._TIMEOUT_MIN);
+            Validator.assertEquals(alertView.getTimeout(), SDL.manager.screen.utils.AlertView._TIMEOUT_MIN);
+        });
+
+        it('testReturnTimeoutUnset', function () {
+            const alertView = new SDL.manager.screen.utils.AlertView();
+            const testDefaultTimeout = 7;
+            alertView.setDefaultTimeout(testDefaultTimeout);
+
+            Validator.assertEquals(alertView.getTimeout(), testDefaultTimeout);
+        });
+
+        it('testReturnTimeoutZero', function () {
+            const alertView = new SDL.manager.screen.utils.AlertView();
+            const testDefaultTimeout = 7;
+            alertView.setDefaultTimeout(testDefaultTimeout);
+            alertView.setTimeout(0);
+
+            Validator.assertEquals(alertView.getTimeout(), testDefaultTimeout);
+        });
+
+        it('testReturnTimeout', function () {
+            const alertView = new SDL.manager.screen.utils.AlertView();
+            const testDefaultTimeout = 7;
+            const testTimeout = 9;
+            alertView.setDefaultTimeout(testDefaultTimeout);
+            alertView.setTimeout(testTimeout);
+
+            Validator.assertEquals(alertView.getTimeout(), testTimeout);
+        });
+
+        it('testReturnMaxTimeout', function () {
+            const alertView = new SDL.manager.screen.utils.AlertView();
+            const testDefaultTimeout = 7;
+            const testTimeout = 214;
+            alertView.setDefaultTimeout(testDefaultTimeout);
+            alertView.setTimeout(testTimeout);
+
+            Validator.assertEquals(alertView.getTimeout(), SDL.manager.screen.utils.AlertView._TIMEOUT_MAX);
+        });
+
+        it('testReturnMinTimeout', function () {
+            const alertView = new SDL.manager.screen.utils.AlertView();
+            const testDefaultTimeout = 7;
+            const testTimeout = 2.25;
+            alertView.setDefaultTimeout(testDefaultTimeout);
+            alertView.setTimeout(testTimeout);
+
+            Validator.assertEquals(alertView.getTimeout(), SDL.manager.screen.utils.AlertView._TIMEOUT_MIN);
+        });
     });
 };

--- a/tests/managers/screen/choiceset/ChoiceSetTests.js
+++ b/tests/managers/screen/choiceset/ChoiceSetTests.js
@@ -31,5 +31,90 @@ module.exports = function (appClient) {
             choiceSet.cancel();
             Validator.assertTrue(canceledHandlerCalled);
         });
+
+        it('testReturnDefaultTimeoutForUnsetTimeout', function () {
+            const choiceSet = new SDL.manager.screen.choiceset.ChoiceSet(Test.GENERAL_STRING, choices, listener);
+            const testDefaultTimeout = 6;
+            choiceSet.setDefaultTimeout(testDefaultTimeout);
+
+            Validator.assertEquals(choiceSet.getDefaultTimeout(), testDefaultTimeout);
+            Validator.assertEquals(choiceSet.getTimeout(), testDefaultTimeout);
+        });
+
+        it('testReturnDefaultTimeoutForSetTimeout', function () {
+            const choiceSet = new SDL.manager.screen.choiceset.ChoiceSet(Test.GENERAL_STRING, choices, listener);
+            const testTimeout = 7;
+            const testDefaultTimeout = 9;
+            choiceSet.setDefaultTimeout(testDefaultTimeout);
+            choiceSet.setTimeout(testTimeout);
+
+            Validator.assertEquals(choiceSet.getDefaultTimeout(), testDefaultTimeout);
+            Validator.assertEquals(choiceSet.getTimeout(), testTimeout);
+        });
+
+        it('testReturnDefaultMaxTimeout', function () {
+            const choiceSet = new SDL.manager.screen.choiceset.ChoiceSet(Test.GENERAL_STRING, choices, listener);
+            const testDefaultTimeout = 155;
+            choiceSet.setDefaultTimeout(testDefaultTimeout);
+
+            Validator.assertEquals(choiceSet.getDefaultTimeout(), 100);
+            Validator.assertEquals(choiceSet.getTimeout(), 100);
+        });
+
+        it('testReturnDefaultMinTimeout', function () {
+            const choiceSet = new SDL.manager.screen.choiceset.ChoiceSet(Test.GENERAL_STRING, choices, listener);
+            const testDefaultTimeout = -3;
+            choiceSet.setDefaultTimeout(testDefaultTimeout);
+
+            Validator.assertEquals(choiceSet.getDefaultTimeout(), 5);
+            Validator.assertEquals(choiceSet.getTimeout(), 5);
+        });
+
+        it('testReturnTimeoutUnset', function () {
+            const choiceSet = new SDL.manager.screen.choiceset.ChoiceSet(Test.GENERAL_STRING, choices, listener);
+            const testDefaultTimeout = 7;
+            choiceSet.setDefaultTimeout(testDefaultTimeout);
+
+            Validator.assertEquals(choiceSet.getTimeout(), testDefaultTimeout);
+        });
+
+        it('testReturnTimeoutZero', function () {
+            const choiceSet = new SDL.manager.screen.choiceset.ChoiceSet(Test.GENERAL_STRING, choices, listener);
+            const testDefaultTimeout = 7;
+            choiceSet.setDefaultTimeout(testDefaultTimeout);
+            choiceSet.setTimeout(0);
+
+            Validator.assertEquals(choiceSet.getTimeout(), testDefaultTimeout);
+        });
+
+        it('testReturnTimeout', function () {
+            const choiceSet = new SDL.manager.screen.choiceset.ChoiceSet(Test.GENERAL_STRING, choices, listener);
+            const testDefaultTimeout = 7;
+            const testTimeout = 9;
+            choiceSet.setDefaultTimeout(testDefaultTimeout);
+            choiceSet.setTimeout(testTimeout);
+
+            Validator.assertEquals(choiceSet.getTimeout(), testTimeout);
+        });
+
+        it('testReturnMaxTimeout', function () {
+            const choiceSet = new SDL.manager.screen.choiceset.ChoiceSet(Test.GENERAL_STRING, choices, listener);
+            const testDefaultTimeout = 7;
+            const testTimeout = 214;
+            choiceSet.setDefaultTimeout(testDefaultTimeout);
+            choiceSet.setTimeout(testTimeout);
+
+            Validator.assertEquals(choiceSet.getTimeout(), 100);
+        });
+
+        it('testReturnMinTimeout', function () {
+            const choiceSet = new SDL.manager.screen.choiceset.ChoiceSet(Test.GENERAL_STRING, choices, listener);
+            const testDefaultTimeout = 7;
+            const testTimeout = 2.25;
+            choiceSet.setDefaultTimeout(testDefaultTimeout);
+            choiceSet.setTimeout(testTimeout);
+
+            Validator.assertEquals(choiceSet.getTimeout(), 5);
+        });
     });
 };


### PR DESCRIPTION
Fixes #396 

### Risk
This PR makes no API changes. (Choice Set is not part of an official release yet)

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Includes tests to check sanitization of timeout values

### Summary
Adds better checks to setting and getting the choice set timeouts. Also includes a missing default timeout parameter in the choice set class and adds tests for those. Timeout values will now behave well when attempting to get their values.
