### PR TITLE
Fix auxillary typo in StaticIconName

### DIFF
--- a/lib/js/src/manager/file/enums/StaticIconName.js
+++ b/lib/js/src/manager/file/enums/StaticIconName.js
@@ -122,10 +122,20 @@ class StaticIconName extends Enum {
     /**
      * Icon Name auxillary audio
      * Gets the enum value for AUXILLARY_AUDIO
+     * @deprecated since version 1.3. Use AUXILIARY_AUDIO instead.
      * @returns {String} - The enum value.
      */
     static get AUXILLARY_AUDIO () {
         return StaticIconName._MAP.AUXILLARY_AUDIO;
+    }
+
+    /**
+     * Icon Name auxiliary audio
+     * Gets the enum value for AUXILIARY_AUDIO
+     * @returns {String} - The enum value.
+     */
+    static get AUXILIARY_AUDIO () {
+        return StaticIconName._MAP.AUXILIARY_AUDIO;
     }
 
     /**
@@ -1659,6 +1669,7 @@ StaticIconName._MAP = Object.freeze({
     'AUDIOBOOK_EPISODE': '0x83',
     'AUDIOBOOK_NARRATOR': '0x82',
     'AUXILLARY_AUDIO': '0x45',
+    'AUXILIARY_AUDIO': '0x45',
     'BACK': '0x86',
     'BATTERY_CAPACITY_0_OF_5': '0xF7',
     'BATTERY_CAPACITY_1_OF_5': '0xF8',


### PR DESCRIPTION
Fixes #398 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

##### Bug Fixes
Fixes the spelling of `AUXILLARY_AUDIO` in the StaticIconName enum.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
