### PR TITLE
Fix positioning of return statement in PermissionManager

### DIFF
--- a/lib/js/src/manager/permission/_PermissionManagerBase.js
+++ b/lib/js/src/manager/permission/_PermissionManagerBase.js
@@ -174,9 +174,8 @@ class _PermissionManagerBase extends _SubManagerBase {
             ) {
                 this._notifyListener(filter);
             }
-
-            return this;
         }
+        return this;
     }
 
     /**


### PR DESCRIPTION
Fixes #403 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Tested with 7.1.0 RC

### Summary
Fixes when the permission manager's _notifyListeners method returns so that all filters are checked. 
