### PR TITLE
ScreenManager Overlapping Button IDs

### DIFF
--- a/lib/js/src/manager/screen/_ScreenManagerBase.js
+++ b/lib/js/src/manager/screen/_ScreenManagerBase.js
@@ -600,10 +600,10 @@ class _ScreenManagerBase extends _SubManagerBase {
         let buttonIdsSetHashSet = new Set();
         if (location === _ManagerLocation.SOFTBUTTON_MANAGER) {
             _ScreenManagerBase._softButtonIDBySoftButtonManager.clear();
-            buttonIdsSetHashSet = _ScreenManagerBase._softButtonIDByAlertManager;
+            buttonIdsSetHashSet = new Set(_ScreenManagerBase._softButtonIDByAlertManager);
         } else if (location === _ManagerLocation.ALERT_MANAGER) {
             _ScreenManagerBase._softButtonIDByAlertManager.clear();
-            buttonIdsSetHashSet = _ScreenManagerBase._softButtonIDBySoftButtonManager;
+            buttonIdsSetHashSet = new Set(_ScreenManagerBase._softButtonIDBySoftButtonManager);
         }
 
         let currentSoftButtonId,

--- a/lib/js/src/manager/screen/_ScreenManagerBase.js
+++ b/lib/js/src/manager/screen/_ScreenManagerBase.js
@@ -597,15 +597,17 @@ class _ScreenManagerBase extends _SubManagerBase {
      * @returns {Boolean} - boolean representing whether the ids are unique or not
      */
     static _checkAndAssignButtonIds (softButtonObjects, location) {
+        let buttonIdsSetHashSet = new Set();
         if (location === _ManagerLocation.SOFTBUTTON_MANAGER) {
             _ScreenManagerBase._softButtonIDBySoftButtonManager.clear();
+            buttonIdsSetHashSet = _ScreenManagerBase._softButtonIDByAlertManager;
         } else if (location === _ManagerLocation.ALERT_MANAGER) {
             _ScreenManagerBase._softButtonIDByAlertManager.clear();
+            buttonIdsSetHashSet = _ScreenManagerBase._softButtonIDBySoftButtonManager;
         }
 
-        const buttonIdsSetHashSet = new Set();
         let currentSoftButtonId,
-            numberOfButtonIdsSet = 0,
+            numberOfButtonIdsSet = buttonIdsSetHashSet.size,
             maxButtonIdsSetByDev = SOFT_BUTTON_ID_MIN_VALUE;
 
         for (const softButtonObject of softButtonObjects) {

--- a/tests/managers/screen/ScreenManagerTests.js
+++ b/tests/managers/screen/ScreenManagerTests.js
@@ -123,9 +123,7 @@ module.exports = function (appClient) {
             Validator.assertTrue(_ScreenManagerBase._checkAndAssignButtonIds(softButtonObjects, _ScreenManagerBase._ManagerLocation.SOFTBUTTON_MANAGER));
             const softButtonObject3 = new SDL.manager.screen.utils.SoftButtonObject('object1', [softButtonState1, softButtonState2], softButtonState1.getName(), null);
             const softButtonObject4 = new SDL.manager.screen.utils.SoftButtonObject('object2', [softButtonState3, softButtonState4], softButtonState3.getName(), null);
-            softButtonObjects.push(softButtonObject3);
-            softButtonObjects.push(softButtonObject4);
-            Validator.assertTrue(_ScreenManagerBase._checkAndAssignButtonIds(softButtonObjects, _ScreenManagerBase._ManagerLocation.SOFTBUTTON_MANAGER));
+            Validator.assertTrue(_ScreenManagerBase._checkAndAssignButtonIds([softButtonObject3, softButtonObject4], _ScreenManagerBase._ManagerLocation.SOFTBUTTON_MANAGER));
             done();
         });
 


### PR DESCRIPTION
Fixes #405 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
This PR fixes the issue that would cause the ScreenManager's sub-managers to generate overlapping button IDs that trigger the same button listeners. The AlertManager will now consider the SoftButtonManager's button IDs and vice versa.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
