### PR TITLE
Fix check for supported audio files in AlertManager

### DIFF
--- a/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
+++ b/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
@@ -338,13 +338,11 @@ class _PresentAlertOperation extends _Task {
         const alertAudioData = alertView.getAudio();
         const ttsChunks = [];
 
-        if (!this.supportsAlertAudioFile()) {
-            for (const chunk of alertAudioData.getAudioData()) {
-                if (chunk.getType() === SpeechCapabilities.FILE && !this.supportsAlertAudioFile()) {
-                    continue;
-                }
-                ttsChunks.push(chunk);
+        for (const chunk of alertAudioData.getAudioData()) {
+            if (chunk.getType() === SpeechCapabilities.FILE && !this.supportsAlertAudioFile()) {
+                continue;
             }
+            ttsChunks.push(chunk);
         }
 
         return ttsChunks.length > 0 ? ttsChunks : null;


### PR DESCRIPTION
Fixes #406 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Testing against 7.1.0 RC

### Summary
Removes an outer if statement in the PresentAlertOperation that only allows the inner code to run if alert audio files are not supported.
