### PR TITLE
Perform null checks for choice set selection listener in manager

### DIFF
--- a/lib/js/src/manager/screen/choiceset/_ChoiceSetManagerBase.js
+++ b/lib/js/src/manager/screen/choiceset/_ChoiceSetManagerBase.js
@@ -347,12 +347,12 @@ class _ChoiceSetManagerBase extends _SubManagerBase {
 
         const listener = new ChoiceSetSelectionListener()
             .setOnChoiceSelected((choiceCell, triggerSource, rowIndex) => {
-                if (this._pendingPresentationSet.getChoiceSetSelectionListener() !== null) {
+                if (this._pendingPresentationSet !== null && this._pendingPresentationSet.getChoiceSetSelectionListener() !== null) {
                     this._pendingPresentationSet.getChoiceSetSelectionListener().onChoiceSelected(choiceCell, triggerSource, rowIndex);
                 }
             })
             .setOnError(error => {
-                if (this._pendingPresentationSet.getChoiceSetSelectionListener() !== null) {
+                if (this._pendingPresentationSet !== null && this._pendingPresentationSet.getChoiceSetSelectionListener() !== null) {
                     this._pendingPresentationSet.getChoiceSetSelectionListener().onError(error);
                 }
             });


### PR DESCRIPTION
Fixes #411 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Tested with RC 7.1.0

### Summary
Adds a null check to the choicesetmanager's _pendingPresentationSet getChoiceSetSelectionListener method before invoking it.