### PR TITLE
Bugfix/duplicate voice command strings

### DIFF
--- a/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
+++ b/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
@@ -144,12 +144,24 @@ class _VoiceCommandUpdateOperation extends _Task {
             return true; // nothing to delete
         }
 
-        // make an AddCommand request for every voice command
-        const addCommands = this._pendingVoiceCommands.map(voiceCommand => {
+        // filter the voice command list of any voice commands with duplicate items
+        const addCommands = this._pendingVoiceCommands.filter(voiceCommand => {
+            // Sets can only hold unique values. The size will be different if there are duplicates
+            const uniqueList = new Set(voiceCommand.getVoiceCommands());
+            if (voiceCommand.getVoiceCommands().length !== uniqueList.size) {
+                return false;
+            }
+            return true;
+        }).map(voiceCommand => {
+            // make an AddCommand request for every voice command
             return new AddCommand()
                 .setCmdID(voiceCommand._getCommandId())
                 .setVrCommands(voiceCommand.getVoiceCommands());
         });
+
+        if (addCommands.length !== this._pendingVoiceCommands.length) {
+            console.log('One or more VoiceCommands contained duplicate items and will not be sent.');
+        }
 
         const addCommandPromises = addCommands.map(addCommand => {
             return this._lifecycleManager.sendRpcResolve(addCommand);


### PR DESCRIPTION
Fixes #413 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

##### Bug Fixes
This PR fixes the case where VoiceCommands with duplicate strings were allowed to be sent. These commands will now be filtered out and an error will logged to notify the developer.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
