### PR TITLE
Fix AlertManager to limit Alerts to 4 soft buttons and trim the list …

### DIFF
--- a/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
+++ b/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
@@ -304,7 +304,7 @@ class _PresentAlertOperation extends _Task {
 
         if (this._alertView.getSoftButtons() !== null) {
             const softButtons = [];
-            for (let index = 0; index < this._alertView.getSoftButtons().length; index++) {
+            for (let index = 0; index < this._getSoftButtonCount(); index++) {
                 softButtons.push(this._alertView.getSoftButtons()[index].getCurrentStateSoftButton());
             }
             alert.setSoftButtons(softButtons);


### PR DESCRIPTION
Fixes #415 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

##### Bug Fixes
AlertViews with more than 4 SoftButtons will be trimmed down when being sent as part of an Alert RPC.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
