### PR TITLE
Blank artwork should be persistent

### DIFF
--- a/lib/js/src/manager/screen/_TextAndGraphicManager.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicManager.js
@@ -53,10 +53,7 @@ class _TextAndGraphicManager extends _TextAndGraphicManagerBase {
      */
     _getBlankArtwork () {
         if (this._blankArtwork === null) {
-            this._blankArtwork = new SdlArtwork();
-            this._blankArtwork.setType(FileType.GRAPHIC_PNG);
-            this._blankArtwork.setName('blankArtwork');
-            this._blankArtwork.setFileData(new Array(50));
+            this._blankArtwork = new SdlArtwork('blankArtwork', FileType.GRAPHIC_PNG, new Array(50), true);
         }
         return this._blankArtwork;
     }


### PR DESCRIPTION
Fixes #417 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

##### Bug Fixes
The blank artwork used by the TextAndGraphicManager will now be uploaded as a persistent file to avoid re-uploading.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
