### PR TITLE
PermissionManager should convert old permissions to RPCStructs after cloning them

### DIFF
--- a/lib/js/src/manager/permission/_PermissionManagerBase.js
+++ b/lib/js/src/manager/permission/_PermissionManagerBase.js
@@ -65,7 +65,7 @@ class _PermissionManagerBase extends _SubManagerBase {
 
         this._onPermissionsChangeListener = (notification) => {
             const permissionItems = notification.getPermissionItem();
-            const previousPermissionItemsJson = JSON.parse(JSON.stringify(this._currentPermissionItems))
+            const previousPermissionItemsJson = JSON.parse(JSON.stringify(this._currentPermissionItems));
             const previousPermissionItems = {};
             Object.entries(previousPermissionItemsJson).map((functionId, permissionObject) => {
                 previousPermissionItems[functionId] = new PermissionItem(permissionObject._parameters);

--- a/lib/js/src/manager/permission/_PermissionManagerBase.js
+++ b/lib/js/src/manager/permission/_PermissionManagerBase.js
@@ -70,7 +70,6 @@ class _PermissionManagerBase extends _SubManagerBase {
             Object.entries(previousPermissionItemsJson).map(([functionId, permissionObject]) => {
                 previousPermissionItems[functionId] = new PermissionItem(permissionObject._parameters);
             });
-            console.log(previousPermissionItems);
             const requireEncryptionAppLevel = notification.getRequireEncryption();
 
             // clear the entire _encryptionRequiredRpcs array to be repopulated

--- a/lib/js/src/manager/permission/_PermissionManagerBase.js
+++ b/lib/js/src/manager/permission/_PermissionManagerBase.js
@@ -67,9 +67,10 @@ class _PermissionManagerBase extends _SubManagerBase {
             const permissionItems = notification.getPermissionItem();
             const previousPermissionItemsJson = JSON.parse(JSON.stringify(this._currentPermissionItems));
             const previousPermissionItems = {};
-            Object.entries(previousPermissionItemsJson).map((functionId, permissionObject) => {
+            Object.entries(previousPermissionItemsJson).map(([functionId, permissionObject]) => {
                 previousPermissionItems[functionId] = new PermissionItem(permissionObject._parameters);
             });
+            console.log(previousPermissionItems);
             const requireEncryptionAppLevel = notification.getRequireEncryption();
 
             // clear the entire _encryptionRequiredRpcs array to be repopulated

--- a/lib/js/src/manager/permission/_PermissionManagerBase.js
+++ b/lib/js/src/manager/permission/_PermissionManagerBase.js
@@ -37,6 +37,7 @@ import { PermissionGroupStatus } from './enums/PermissionGroupStatus.js';
 import { PermissionStatus } from './PermissionStatus.js';
 import { FunctionID } from '../../rpc/enums/FunctionID.js';
 import { PredefinedWindows } from '../../rpc/enums/PredefinedWindows.js';
+import { PermissionItem } from '../../rpc/structs/PermissionItem.js';
 
 class _PermissionManagerBase extends _SubManagerBase {
     /**
@@ -64,7 +65,11 @@ class _PermissionManagerBase extends _SubManagerBase {
 
         this._onPermissionsChangeListener = (notification) => {
             const permissionItems = notification.getPermissionItem();
-            const previousPermissionItems = JSON.parse(JSON.stringify(this._currentPermissionItems));
+            const previousPermissionItemsJson = JSON.parse(JSON.stringify(this._currentPermissionItems))
+            const previousPermissionItems = {};
+            Object.entries(previousPermissionItemsJson).map((functionId, permissionObject) => {
+                previousPermissionItems[functionId] = new PermissionItem(permissionObject._parameters);
+            });
             const requireEncryptionAppLevel = notification.getRequireEncryption();
 
             // clear the entire _encryptionRequiredRpcs array to be repopulated


### PR DESCRIPTION
Fixes #422 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

##### Bug Fixes
This PR fixes the case where an app would receive an OnPermissionsChange notification from core and clone its old PermissionItems but not convert them to PermissionItems.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
