### PR TITLE
Voice command should not contain duplicate strings

### DIFF
--- a/lib/js/src/manager/screen/utils/VoiceCommand.js
+++ b/lib/js/src/manager/screen/utils/VoiceCommand.js
@@ -39,7 +39,7 @@ class VoiceCommand {
      */
     constructor (voiceCommands = [], voiceCommandSelectionListener = null) {
         // The strings the user can say to activate this voice command
-        this._voiceCommands = voiceCommands;
+        this._voiceCommands = Array.from(new Set(voiceCommands));
         // The listener that will be called when the command is activated
         this._voiceCommandSelectionListener = voiceCommandSelectionListener;
         // Used Internally to identify the command
@@ -53,7 +53,7 @@ class VoiceCommand {
      */
     setVoiceCommands (voiceCommands) {
         if (Array.isArray(voiceCommands)) {
-            this._voiceCommands = voiceCommands;
+            this._voiceCommands = Array.from(new Set(voiceCommands));
         } else {
             console.error(new Error('setVoiceCommands argument is not an array'));
         }

--- a/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
+++ b/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
@@ -145,23 +145,12 @@ class _VoiceCommandUpdateOperation extends _Task {
         }
 
         // filter the voice command list of any voice commands with duplicate items
-        const addCommands = this._pendingVoiceCommands.filter(voiceCommand => {
-            // Sets can only hold unique values. The size will be different if there are duplicates
-            const uniqueList = new Set(voiceCommand.getVoiceCommands());
-            if (voiceCommand.getVoiceCommands().length !== uniqueList.size) {
-                return false;
-            }
-            return true;
-        }).map(voiceCommand => {
+        const addCommands = this._pendingVoiceCommands.map(voiceCommand => {
             // make an AddCommand request for every voice command
             return new AddCommand()
                 .setCmdID(voiceCommand._getCommandId())
                 .setVrCommands(voiceCommand.getVoiceCommands());
         });
-
-        if (addCommands.length !== this._pendingVoiceCommands.length) {
-            console.log('One or more VoiceCommands contained duplicate items and will not be sent.');
-        }
 
         const addCommandPromises = addCommands.map(addCommand => {
             return this._lifecycleManager.sendRpcResolve(addCommand);

--- a/tests/managers/screen/VoiceCommandManagerTests.js
+++ b/tests/managers/screen/VoiceCommandManagerTests.js
@@ -15,10 +15,19 @@ module.exports = async function (appClient) {
         const voiceCommand2 = new SDL.manager.screen.utils.VoiceCommand(['Command 3', 'Command 4'], () => {});
 
         const voiceCommands = [voiceCommand1, voiceCommand2];
+        const voiceCommands2 = ['Test 1', 'Test 1', 'Test 1'];
 
         beforeEach(function (done) {
             voiceCommandManager._currentHmiLevel = SDL.rpc.enums.HMILevel.HMI_FULL;
             voiceCommandManager._voiceCommands = [];
+            done();
+        });
+
+        it('should initialize properly if it has multiple of the same command string', function (done) {
+            const testCommand2 = new SDL.manager.screen.utils.VoiceCommand(voiceCommands2);
+
+            Validator.assertTrue(testCommand2.getVoiceCommands() !== voiceCommands2);
+            Validator.assertEquals(testCommand2.getVoiceCommands().length, 1);
             done();
         });
 


### PR DESCRIPTION
Fixes #430 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Adds a unit test to ensure that the VoiceCommand class removes all duplicates.

### Summary
The VoiceCommand class will now convert the provided string array into a Set to ensure uniqueness among the strings, then convert back to an array.

### Changelog
##### Bug Fixes
Fixes the case where VoiceCommands could be sent with duplicates of the same string.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
