### PR TITLE
check whether separate voice commands contain the same string

### DIFF
--- a/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
+++ b/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
@@ -88,6 +88,11 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
             return;
         }
 
+        if (!this._arePendingVoiceCommandsUnique(voiceCommands)) {
+            console.log('Not all voice command strings are unique across all voice commands. Voice commands will not be set.');
+            return;
+        }
+
         this._updateIdsOnVoiceCommands(voiceCommands);
         this._voiceCommands = voiceCommands;
 
@@ -126,6 +131,23 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
      */
     getVoiceCommands () {
         return this._voiceCommands;
+    }
+
+    /**
+     * Determines if all provided voice commands are unique
+     * @param {VoiceCommand[]} voiceCommands - An array of VoiceCommand instances.
+     * @returns {Boolean} - indicate whether all voice commands are unique
+     */
+    _arePendingVoiceCommandsUnique (voiceCommands) {
+        let voiceCommandCount = 0;
+        const voiceCommandsSet = new Set();
+        voiceCommands.forEach((voiceCommand) => {
+            console.log(voiceCommand);
+            voiceCommand.getVoiceCommands().forEach(item => voiceCommandsSet.add(item));
+            voiceCommandCount += voiceCommand.getVoiceCommands().length;
+        });
+
+        return (voiceCommandsSet.size === voiceCommandCount);
     }
 
     /**

--- a/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
+++ b/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
@@ -139,15 +139,8 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
      * @returns {Boolean} - indicate whether all voice commands are unique
      */
     _arePendingVoiceCommandsUnique (voiceCommands) {
-        let voiceCommandCount = 0;
-        const voiceCommandsSet = new Set();
-        voiceCommands.forEach((voiceCommand) => {
-            console.log(voiceCommand);
-            voiceCommand.getVoiceCommands().forEach(item => voiceCommandsSet.add(item));
-            voiceCommandCount += voiceCommand.getVoiceCommands().length;
-        });
-
-        return (voiceCommandsSet.size === voiceCommandCount);
+        const allVoiceCommands = voiceCommands.map(voiceCommand => voiceCommand.getVoiceCommands()).flat();
+        return new Set(allVoiceCommands).size === allVoiceCommands.length;
     }
 
     /**

--- a/tests/managers/screen/VoiceCommandManagerTests.js
+++ b/tests/managers/screen/VoiceCommandManagerTests.js
@@ -13,6 +13,7 @@ module.exports = async function (appClient) {
 
         const voiceCommand1 = new SDL.manager.screen.utils.VoiceCommand(['Command 1', 'Command 2'], () => {});
         const voiceCommand2 = new SDL.manager.screen.utils.VoiceCommand(['Command 3', 'Command 4'], () => {});
+        const voiceCommand3 = new SDL.manager.screen.utils.VoiceCommand(['Command 1', 'Command 2', 'Command 3', 'Command 4'], () => {});
 
         const voiceCommands = [voiceCommand1, voiceCommand2];
 
@@ -66,6 +67,17 @@ module.exports = async function (appClient) {
 
             // verify the mock listener has been hit once
             Validator.assertEquals(callback.calledOnce, true);
+        });
+
+        describe('when new voice commands are set and have duplicate strings in different voice commands', function () {
+            beforeEach(function () {
+                voiceCommandManager.setVoiceCommands([voiceCommand2, voiceCommand3]);
+            });
+
+            it('should only have one operation', function () {
+                Validator.assertEquals(voiceCommandManager._getTasks().length, 1);
+                Validator.assertTrue(!voiceCommandManager._arePendingVoiceCommandsUnique([voiceCommand2, voiceCommand3]));
+            });
         });
 
         after(function () {


### PR DESCRIPTION
Fixes #432 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Changelog
##### Bug Fixes
* Setting multiple voice commands with the VoiceCommandManager will check that each voice command contains unique strings from the other voice commands.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
