### PR TITLE
Fix manager to not delete and set identical voice commands

### DIFF
--- a/lib/js/src/manager/screen/_ScreenManagerBase.js
+++ b/lib/js/src/manager/screen/_ScreenManagerBase.js
@@ -438,7 +438,7 @@ class _ScreenManagerBase extends _SubManagerBase {
     }
 
     /**
-     * Get the currently set voice commands
+     * Gets the voice commands set as part of the last initiated update operation
      * @returns {VoiceCommand[]} - a List of Voice Command objects
      */
     getVoiceCommands () {

--- a/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
+++ b/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
@@ -84,24 +84,27 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
      */
     async setVoiceCommands (voiceCommands) {
         // we actually need voice commands to set. checks if the array of voice commands passed in contains the same content as the current voice commands
-        if (!Array.isArray(voiceCommands) || (voiceCommands.length > 0 && !voiceCommands.map((vc, index) => vc.equals(this._originalVoiceCommands[index])).includes(false))) {
-            console.log('Voice commands list non-existent or matches the current voice commands');
+        if (!Array.isArray(voiceCommands)) {
+            console.log('Voice commands list non-existent');
             return;
         }
+
+        this._voiceCommands = voiceCommands.map((vc) => vc.clone());
 
         const validatedVoiceCommands = this._removeEmptyVoiceCommands(voiceCommands);
         if (voiceCommands.length > 0 && validatedVoiceCommands.length === 0) {
             console.log('New voice commands are invalid, skipping...');
+            this._voiceCommands = null;
             return;
         }
 
         // check uniqueness before updating the IDs since changing the IDs would make them all unique
         if (!this._arePendingVoiceCommandsUnique(validatedVoiceCommands)) {
             console.log('Not all voice command strings are unique across all voice commands. Voice commands will not be set.');
+            this._voiceCommands = null;
             return;
         }
 
-        this._originalVoiceCommands = voiceCommands;
         this._voiceCommands = validatedVoiceCommands;
 
         this._updateIdsOnVoiceCommands(this._voiceCommands);
@@ -136,7 +139,7 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
     }
 
     /**
-     * Gets all the voice commands currently set
+     * Gets all the voice commands set as part of the last initiated update operation
      * @returns {VoiceCommand[]} - An array of VoiceCommand instances.
      */
     getVoiceCommands () {
@@ -163,7 +166,7 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
             if (task.getState() === _Task.IN_PROGRESS) {
                 return;
             }
-            task._oldVoiceCommands = voiceCommands;
+            task._setOldVoiceCommands(voiceCommands);
         });
     }
 
@@ -197,7 +200,7 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
         this._commandListener = (onCommand) => {
             // find and invoke the listener of the matching command
             const targetCommandId = onCommand.getCmdID();
-            for (const command of this._voiceCommands) {
+            for (const command of this._currentVoiceCommands) {
                 if (targetCommandId === command._getCommandId()) {
                     const listener = command.getVoiceCommandSelectionListener();
                     if (typeof listener === 'function') {

--- a/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
+++ b/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
@@ -91,7 +91,7 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
 
         this._voiceCommands = voiceCommands.map((vc) => vc.clone());
 
-        const validatedVoiceCommands = this._removeEmptyVoiceCommands(voiceCommands);
+        const validatedVoiceCommands = this._removeEmptyVoiceCommands(this._voiceCommands);
         if (voiceCommands.length > 0 && validatedVoiceCommands.length === 0) {
             console.log('New voice commands are invalid, skipping...');
             this._voiceCommands = null;

--- a/lib/js/src/manager/screen/utils/VoiceCommand.js
+++ b/lib/js/src/manager/screen/utils/VoiceCommand.js
@@ -142,6 +142,10 @@ class VoiceCommand {
         return true;
     }
 
+    /**
+     * Creates a deep copy of the object
+     * @returns {VoiceCommand} - A deep clone of the object
+     */
     clone () {
         const clone = new VoiceCommand(
             JSON.parse(JSON.stringify(this.getVoiceCommands()))

--- a/lib/js/src/manager/screen/utils/VoiceCommand.js
+++ b/lib/js/src/manager/screen/utils/VoiceCommand.js
@@ -129,10 +129,6 @@ class VoiceCommand {
         if (!(other instanceof VoiceCommand)) {
             return false;
         }
-        // main comparison check
-        if (this._getCommandId() !== other._getCommandId()) {
-            return false;
-        }
         const voiceCommands = this.getVoiceCommands();
         const otherVoiceCommands = other.getVoiceCommands();
         if (voiceCommands.length !== otherVoiceCommands.length) {
@@ -144,6 +140,23 @@ class VoiceCommand {
             }
         }
         return true;
+    }
+
+    clone () {
+        const clone = new VoiceCommand(
+            JSON.parse(JSON.stringify(this.getVoiceCommands()))
+        );
+        if (typeof this._getCommandId() === 'number') {
+            clone._setCommandId(
+                parseInt(JSON.stringify(this._getCommandId()))
+            );
+        }
+
+        if (typeof this.getVoiceCommandSelectionListener() === 'function') {
+            // Re-bind the context of the listener to make a clone of the method
+            clone.setVoiceCommandSelectionListener(this.getVoiceCommandSelectionListener().bind(clone));
+        }
+        return clone;
     }
 }
 

--- a/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
+++ b/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
@@ -82,11 +82,6 @@ class _VoiceCommandUpdateOperation extends _Task {
         this.onFinished();
     }
 
-    _setOldVoiceCommands (oldVoiceCommands) {
-        this._oldVoiceCommands = oldVoiceCommands;
-        this._currentVoiceCommands = Array.from(oldVoiceCommands);
-    }
-
     /**
      * Sends requests to delete all old/current voice commands passed in
      * @private

--- a/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
+++ b/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
@@ -82,18 +82,24 @@ class _VoiceCommandUpdateOperation extends _Task {
         this.onFinished();
     }
 
+    _setOldVoiceCommands (oldVoiceCommands) {
+        this._oldVoiceCommands = oldVoiceCommands;
+        this._currentVoiceCommands = Array.from(oldVoiceCommands);
+    }
+
     /**
      * Sends requests to delete all old/current voice commands passed in
      * @private
      * @returns {Promise} - A promise which returns a Boolean of whether the operation is a success
      */
     async _sendDeleteCurrentVoiceCommands () {
-        if (!Array.isArray(this._oldVoiceCommands) || this._oldVoiceCommands.length === 0) {
+        const voiceCommandsToDelete = this._voiceCommandsNotInSecondArray(this._oldVoiceCommands, this._pendingVoiceCommands);
+        if (voiceCommandsToDelete.length === 0) {
             return true; // nothing to delete
         }
 
         // make a DeleteCommand request for every voice command
-        const deleteCommands = this._oldVoiceCommands.map(voiceCommand => {
+        const deleteCommands = voiceCommandsToDelete.map(voiceCommand => {
             return new DeleteCommand().setCmdID(voiceCommand._getCommandId());
         });
 
@@ -120,6 +126,32 @@ class _VoiceCommandUpdateOperation extends _Task {
     }
 
     /**
+     * Returns
+     * @param {VoiceCommmand[]} firstArray - an array of VoiceCommands
+     * @param {VoiceCommand[]} secondArray - an array of VoiceCommands
+     * @returns {VoiceCommand[]} - A list of VoiceCommands that are in the first array but not the second
+     */
+    _voiceCommandsNotInSecondArray (firstArray, secondArray) {
+        if (secondArray.length === 0) {
+            return firstArray;
+        }
+
+        const differenceArray = [];
+        for (let iterator = 0; iterator < firstArray.length; iterator++) {
+            const checkVC = firstArray[iterator];
+            for (let jterator = 0; jterator < secondArray.length; jterator++) {
+                if (checkVC.equals(secondArray[jterator])) {
+                    break;
+                }
+                if (jterator === secondArray.length - 1) {
+                    differenceArray.push(checkVC);
+                }
+            }
+        }
+        return Array.from(differenceArray);
+    }
+
+    /**
      * Removes this delete command from the current voice commands array
      * @private
      * @param {DeleteCommand} deleteCommand - The command to remove
@@ -140,12 +172,13 @@ class _VoiceCommandUpdateOperation extends _Task {
      * @returns {Promise} - A promise which returns a Boolean of whether the operation is a success
      */
     async _sendCurrentVoiceCommands () {
-        if (!Array.isArray(this._pendingVoiceCommands) || this._pendingVoiceCommands.length === 0) {
-            return true; // nothing to delete
+        const voiceCommandsToAdd = this._voiceCommandsNotInSecondArray(this._pendingVoiceCommands, this._oldVoiceCommands);
+        if (voiceCommandsToAdd.length === 0) {
+            return true; // nothing to send
         }
 
         // filter the voice command list of any voice commands with duplicate items
-        const addCommands = this._pendingVoiceCommands.filter(voiceCommand => {
+        const addCommands = voiceCommandsToAdd.filter(voiceCommand => {
             // Sets can only hold unique values. The size will be different if there are duplicates
             const uniqueList = new Set(voiceCommand.getVoiceCommands());
             if (voiceCommand.getVoiceCommands().length !== uniqueList.size) {

--- a/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
+++ b/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
@@ -68,6 +68,17 @@ class _VoiceCommandUpdateOperation extends _Task {
             this.onFinished();
             return;
         }
+
+        if (Array.isArray(this._pendingVoiceCommands) && this._pendingVoiceCommands.length > 0) {
+            for (const voiceCommand of this._pendingVoiceCommands) {
+                this._currentVoiceCommands.forEach((vc) => {
+                    if (vc.equals(voiceCommand)) {
+                        voiceCommand.setVoiceCommandSelectionListener(vc.getVoiceCommandSelectionListener());
+                    }
+                });
+            }
+        }
+
         await this._sendDeleteCurrentVoiceCommands();
         if (this.getState() === _Task.CANCELED) {
             this.onFinished();
@@ -88,6 +99,10 @@ class _VoiceCommandUpdateOperation extends _Task {
      * @returns {Promise} - A promise which returns a Boolean of whether the operation is a success
      */
     async _sendDeleteCurrentVoiceCommands () {
+        if (!Array.isArray(this._oldVoiceCommands) || this._oldVoiceCommands.length === 0) {
+            return true;
+        }
+
         const voiceCommandsToDelete = this._voiceCommandsNotInSecondArray(this._oldVoiceCommands, this._pendingVoiceCommands);
         if (voiceCommandsToDelete.length === 0) {
             return true; // nothing to delete
@@ -132,17 +147,13 @@ class _VoiceCommandUpdateOperation extends _Task {
         }
 
         const differenceArray = [];
-        for (let iterator = 0; iterator < firstArray.length; iterator++) {
-            const checkVC = firstArray[iterator];
-            for (let jterator = 0; jterator < secondArray.length; jterator++) {
-                if (checkVC.equals(secondArray[jterator])) {
-                    break;
-                }
-                if (jterator === secondArray.length - 1) {
-                    differenceArray.push(checkVC);
-                }
+
+        firstArray.forEach((checkVC) => {
+            if (!secondArray.map((secondVC) => checkVC.equals(secondVC)).includes(true)) {
+                differenceArray.push(checkVC);
             }
-        }
+        });
+
         return Array.from(differenceArray);
     }
 
@@ -216,6 +227,15 @@ class _VoiceCommandUpdateOperation extends _Task {
                 return;
             }
         }
+    }
+
+    /**
+     * Updates the voice commands in the task in case another operation has made updates
+     * @param {VoiceCommand[]} oldVoiceCommands - An Array of VoiceCommands
+     */
+    _setOldVoiceCommands (oldVoiceCommands) {
+        this._oldVoiceCommands = oldVoiceCommands;
+        this._currentVoiceCommands = Array.from(oldVoiceCommands);
     }
 }
 

--- a/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
+++ b/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
@@ -141,8 +141,11 @@ class _VoiceCommandUpdateOperation extends _Task {
      * @param {VoiceCommand[]} secondArray - an array of VoiceCommands
      * @returns {VoiceCommand[]} - An array of VoiceCommands that are in the first array but not the second array
      */
-    _voiceCommandsNotInSecondArray (firstArray, secondArray) {
-        if (secondArray.length === 0) {
+    _voiceCommandsNotInSecondArray (firstArray = null, secondArray = null) {
+        if (!Array.isArray(firstArray) || firstArray.length === 0) {
+            return secondArray;
+        }
+        if (!Array.isArray(secondArray) || secondArray.length === 0) {
             return firstArray;
         }
 
@@ -179,7 +182,7 @@ class _VoiceCommandUpdateOperation extends _Task {
      */
     async _sendCurrentVoiceCommands () {
         const voiceCommandsToAdd = this._voiceCommandsNotInSecondArray(this._pendingVoiceCommands, this._oldVoiceCommands);
-        if (voiceCommandsToAdd.length === 0) {
+        if (!Array.isArray(voiceCommandsToAdd) || voiceCommandsToAdd.length === 0) {
             return true; // nothing to send
         }
 

--- a/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
+++ b/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
@@ -143,7 +143,7 @@ class _VoiceCommandUpdateOperation extends _Task {
      */
     _voiceCommandsNotInSecondArray (firstArray = null, secondArray = null) {
         if (!Array.isArray(firstArray) || firstArray.length === 0) {
-            return secondArray;
+            return [];
         }
         if (!Array.isArray(secondArray) || secondArray.length === 0) {
             return firstArray;

--- a/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
+++ b/lib/js/src/manager/screen/utils/_VoiceCommandUpdateOperation.js
@@ -126,10 +126,10 @@ class _VoiceCommandUpdateOperation extends _Task {
     }
 
     /**
-     * Returns
+     * Returns an array of VoiceCommands that are in the first array but not the second array
      * @param {VoiceCommmand[]} firstArray - an array of VoiceCommands
      * @param {VoiceCommand[]} secondArray - an array of VoiceCommands
-     * @returns {VoiceCommand[]} - A list of VoiceCommands that are in the first array but not the second
+     * @returns {VoiceCommand[]} - An array of VoiceCommands that are in the first array but not the second array
      */
     _voiceCommandsNotInSecondArray (firstArray, secondArray) {
         if (secondArray.length === 0) {

--- a/tests/managers/screen/VoiceCommandManagerTests.js
+++ b/tests/managers/screen/VoiceCommandManagerTests.js
@@ -135,6 +135,15 @@ module.exports = async function (appClient) {
             });
         });
 
+        it('clone should not keep reference', function (done) {
+            const voiceCommand = new SDL.manager.screen.utils.VoiceCommand(['Command 1', 'Command 2'], () => {});
+            const clone = voiceCommand.clone();
+            Validator.assertTrue(clone.equals(voiceCommand));
+            clone.setVoiceCommands(['Command 3']);
+            Validator.assertTrue(!clone.equals(voiceCommand));
+            done();
+        });
+
         after(function () {
             voiceCommandManager.dispose();
 

--- a/tests/managers/screen/VoiceCommandUpdateOperationTests.js
+++ b/tests/managers/screen/VoiceCommandUpdateOperationTests.js
@@ -176,7 +176,6 @@ module.exports = function (appClient) {
             });
             it('Should not delete or upload the voiceCommands', function (done) {
                 Validator.assertEquals(callbackCurrentVoiceCommands.length, 2);
-                console.log(callbackError);
                 Validator.assertEquals(callbackError.length, 0);
                 done();
             });

--- a/tests/managers/screen/VoiceCommandUpdateOperationTests.js
+++ b/tests/managers/screen/VoiceCommandUpdateOperationTests.js
@@ -10,11 +10,13 @@ module.exports = function (appClient) {
     describe('VoiceCommandUpdateOperationTests', function () {
         const sdlManager = appClient._sdlManager;
         const lifecycleManager = sdlManager._lifecycleManager;
+        const voiceCommandManager = sdlManager.getScreenManager()._voiceCommandManager;
 
         const voiceCommand1 = new SDL.manager.screen.utils.VoiceCommand(['Command 1'], () => {});
         const voiceCommand2 = new SDL.manager.screen.utils.VoiceCommand(['Command 2'], () => {});
         const voiceCommand3 = new SDL.manager.screen.utils.VoiceCommand(['Command 3'], () => {});
         const voiceCommand4 = new SDL.manager.screen.utils.VoiceCommand(['Command 4'], () => {});
+        const voiceCommand5 = new SDL.manager.screen.utils.VoiceCommand(['Command 1', 'Command 2', 'Command 3', 'Command 4'], () => {});
 
         let deleteList = [];
         let addList = [];
@@ -145,5 +147,196 @@ module.exports = function (appClient) {
                     .setSuccess(false);
             }
         }
+
+        describe('when updating oldVoiceCommands', function () {
+            let testOp;
+            beforeEach(function () {
+                testOp = new SDL.manager.screen.utils._VoiceCommandUpdateOperation();
+                testOp._setOldVoiceCommands([voiceCommand5]);
+            });
+
+            // should update both oldVoiceCommands and currentVoiceCommands
+            it('should update both oldVoiceCommands and currentVoiceCommands', function (done) {
+                Validator.assertEquals(testOp._oldVoiceCommands, [voiceCommand5]);
+                Validator.assertEquals(testOp._currentVoiceCommands, testOp._oldVoiceCommands);
+                done();
+            });
+        });
+
+        describe('if it has pending voice commands identical to old voice commands', function () {
+            let callbackCurrentVoiceCommands;
+            let callbackError;
+            beforeEach(async function () {
+                const testOp = new SDL.manager.screen.utils._VoiceCommandUpdateOperation(voiceCommandManager._lifecycleManager, [voiceCommand1, voiceCommand2], [voiceCommand1, voiceCommand2], (newCurrentVoiceCommands, errorArray) => {
+                    callbackCurrentVoiceCommands = newCurrentVoiceCommands;
+                    callbackError = errorArray;
+                });
+                await testOp.onExecute();
+            });
+            it('Should not delete or upload the voiceCommands', function (done) {
+                Validator.assertEquals(callbackCurrentVoiceCommands.length, 2);
+                Validator.assertEquals(callbackError.length, 0);
+                done();
+            });
+        });
+
+        // going from voice commands [AB] to [A]
+        describe('going from voice commands [AB] to [A]', function () {
+            /**
+             * Handle Delete successes.
+             * @returns {Promise} - A promise.
+             */
+            function onDeleteSuccess () {
+                const deleteOld1 = new SDL.rpc.messages.DeleteCommandResponse({
+                    functionName: SDL.rpc.enums.FunctionID.DeleteCommandResponse,
+                })
+                    .setSuccess(true)
+                    .setResultCode(SDL.rpc.enums.Result.SUCCESS);
+
+                sdlManager._lifecycleManager._handleRpc(deleteOld1);
+
+                return new Promise((resolve, reject) => {
+                    resolve(deleteOld1);
+                });
+            }
+
+            let stub;
+            let callbackCurrentVoiceCommands;
+            let callbackError;
+            before(async () => {
+                stub = sinon.stub(sdlManager._lifecycleManager, 'sendRpcResolve')
+                    .callsFake(onDeleteSuccess);
+                const testOp = new SDL.manager.screen.utils._VoiceCommandUpdateOperation(voiceCommandManager._lifecycleManager, [voiceCommand1, voiceCommand2], [voiceCommand1], (newCurrentVoiceCommands, errorArray) => {
+                    callbackCurrentVoiceCommands = newCurrentVoiceCommands;
+                    callbackError = errorArray;
+                });
+                await testOp.onExecute();
+            });
+
+            // and the delete succeeds
+            describe('and the delete succeeds', function () {
+                it('Should only delete voiceCommands thats not in common', function (done) {
+                    Validator.assertEquals(callbackCurrentVoiceCommands.length, 1);
+                    Validator.assertEquals(callbackError.length, 0);
+                    done();
+                });
+            });
+
+            after(() => {
+                stub.restore();
+            });
+        });
+
+        // going from voice commands [A] to [AB]
+        describe('going from voice commands [A] to [AB]', function () {
+            /**
+             * Handle Add successes.
+             * @returns {Promise} - A promise.
+             */
+            function onAddCommandSuccess () {
+                const addNew1 = new SDL.rpc.messages.AddCommandResponse({
+                    functionName: SDL.rpc.enums.FunctionID.AddCommandResponse,
+                })
+                    .setSuccess(true)
+                    .setResultCode(SDL.rpc.enums.Result.SUCCESS);
+                // _handleRpc triggers the listener
+                sdlManager._lifecycleManager._handleRpc(addNew1);
+
+                return new Promise((resolve, reject) => {
+                    resolve(addNew1);
+                });
+            }
+
+            let stub;
+            let callbackCurrentVoiceCommands;
+            let callbackError;
+
+            beforeEach(async function () {
+                stub = sinon.stub(sdlManager._lifecycleManager, 'sendRpcResolve')
+                    .callsFake(onAddCommandSuccess);
+                const testOp = new SDL.manager.screen.utils._VoiceCommandUpdateOperation(voiceCommandManager._lifecycleManager, [voiceCommand1], [voiceCommand1, voiceCommand2], (newCurrentVoiceCommands, errorArray) => {
+                    callbackCurrentVoiceCommands = newCurrentVoiceCommands;
+                    callbackError = errorArray;
+                });
+                await testOp.onExecute();
+            });
+
+            // and the add succeeds
+            describe('and the add succeeds', function () {
+                it('should only upload the voiceCommand thats not in common and not delete anything', function (done) {
+                    Validator.assertEquals(callbackCurrentVoiceCommands.length, 2);
+                    Validator.assertEquals(callbackError.length, 0);
+                    done();
+                });
+            });
+
+            after(() => {
+                stub.restore();
+            });
+        });
+
+        // going from voice commands [AB] to [CD]
+        describe('going from voice commands [AB] to [CD]', function () {
+            /**
+             * Handle Add or Delete successes.
+             * @param {RpcMessage} rpc - an AddCommand or DeleteCommand rpc
+             * @returns {Promise} - A promise.
+             */
+            function onAddOrDeleteSuccess (rpc) {
+                if (rpc instanceof SDL.rpc.messages.AddCommand) {
+                    const addNew1 = new SDL.rpc.messages.AddCommandResponse({
+                        functionName: SDL.rpc.enums.FunctionID.AddCommandResponse,
+                    })
+                        .setSuccess(true)
+                        .setResultCode(SDL.rpc.enums.Result.SUCCESS);
+                    // _handleRpc triggers the listener
+                    sdlManager._lifecycleManager._handleRpc(addNew1);
+
+                    return new Promise((resolve, reject) => {
+                        resolve(addNew1);
+                    });
+                } else if (rpc instanceof SDL.rpc.messages.DeleteCommand) {
+                    const deleteOld1 = new SDL.rpc.messages.DeleteCommandResponse({
+                        functionName: SDL.rpc.enums.FunctionID.DeleteCommandResponse,
+                    })
+                        .setSuccess(true)
+                        .setResultCode(SDL.rpc.enums.Result.SUCCESS);
+                    // _handleRpc triggers the listener
+                    sdlManager._lifecycleManager._handleRpc(deleteOld1);
+
+                    return new Promise((resolve, reject) => {
+                        resolve(deleteOld1);
+                    });
+                }
+                return;
+            }
+
+            let stub;
+            let callbackCurrentVoiceCommands;
+            let callbackError;
+
+            before(async () => {
+                stub = sinon.stub(sdlManager._lifecycleManager, 'sendRpcResolve')
+                    .callsFake(onAddOrDeleteSuccess);
+                const testOp = new SDL.manager.screen.utils._VoiceCommandUpdateOperation(voiceCommandManager._lifecycleManager, [voiceCommand1, voiceCommand2], [voiceCommand5], (newCurrentVoiceCommands, errorArray) => {
+                    callbackCurrentVoiceCommands = newCurrentVoiceCommands;
+                    callbackError = errorArray;
+                });
+                await testOp.onExecute();
+            });
+
+            // the delete and add commands succeeds
+            describe('the delete and add commands succeeds', function () {
+                it('should delete and upload the voiceCommands', function (done) {
+                    Validator.assertEquals(callbackCurrentVoiceCommands[0].getVoiceCommands().length, 4);
+                    Validator.assertEquals(callbackError.length, 0);
+                    done();
+                });
+            });
+
+            after(() => {
+                stub.restore();
+            });
+        });
     });
 };

--- a/tests/managers/screen/VoiceCommandUpdateOperationTests.js
+++ b/tests/managers/screen/VoiceCommandUpdateOperationTests.js
@@ -176,6 +176,7 @@ module.exports = function (appClient) {
             });
             it('Should not delete or upload the voiceCommands', function (done) {
                 Validator.assertEquals(callbackCurrentVoiceCommands.length, 2);
+                console.log(callbackError);
                 Validator.assertEquals(callbackError.length, 0);
                 done();
             });

--- a/tests/managers/screen/VoiceCommandUpdateOperationTests.js
+++ b/tests/managers/screen/VoiceCommandUpdateOperationTests.js
@@ -152,7 +152,8 @@ module.exports = function (appClient) {
             let testOp;
             beforeEach(function () {
                 testOp = new SDL.manager.screen.utils._VoiceCommandUpdateOperation();
-                testOp._setOldVoiceCommands([voiceCommand5]);
+                testOp._oldVoiceCommands = [voiceCommand5];
+                testOp._currentVoiceCommands = Array.from([voiceCommand5]);
             });
 
             // should update both oldVoiceCommands and currentVoiceCommands


### PR DESCRIPTION
Fixes #433 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Added unit tests to verify that VoiceCommands are added/deleted correctly.

### Changelog
##### Bug Fixes
* The VoiceCommandManager will no longer delete a VoiceCommand if the VoiceCommand is going to be immediately added again as part of the same update operation. Below is sample code that can be used to test the functionality. Option 1-3 will be added as part of the first operation. The second operation will delete Option 3 and add Option 4 while leaving Option 1/2 untouched.
```
const voiceCommands = [
    new SDL.manager.screen.utils.VoiceCommand(['Option 1'], () => {}),
    new SDL.manager.screen.utils.VoiceCommand(['Option 2'], () => {}),
    new SDL.manager.screen.utils.VoiceCommand(['Option 3'], () => {}),
];

await screenManager.setVoiceCommands(voiceCommands);
const newVoiceCommands = [
    voiceCommands[0],
    voiceCommands[1],
    new SDL.manager.screen.utils.VoiceCommand(['Option 4'], () => {}),
]
await screenManager.setVoiceCommands(newVoiceCommands);
```

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
