### PR TITLE
Fix for voice command that contains no string should be removed

### DIFF
--- a/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
+++ b/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
@@ -95,16 +95,16 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
             return;
         }
 
-        this._originalVoiceCommands = voiceCommands;
-        this._voiceCommands = validatedVoiceCommands;
-        this._updateIdsOnVoiceCommands(this._voiceCommands);
-        if (!this._arePendingVoiceCommandsUnique(voiceCommands)) {
+        // check uniqueness before updating the IDs since changing the IDs would make them all unique
+        if (!this._arePendingVoiceCommandsUnique(validatedVoiceCommands)) {
             console.log('Not all voice command strings are unique across all voice commands. Voice commands will not be set.');
             return;
         }
 
-        this._updateIdsOnVoiceCommands(voiceCommands);
-        this._voiceCommands = voiceCommands;
+        this._originalVoiceCommands = voiceCommands;
+        this._voiceCommands = validatedVoiceCommands;
+
+        this._updateIdsOnVoiceCommands(this._voiceCommands);
 
         // add the commands to a queue to be processed later
         // clear all tasks

--- a/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
+++ b/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
@@ -185,7 +185,7 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
         }).filter((voiceCommand) => {
             return voiceCommand !== undefined;
         });
-        return Array.from(validatedVoiceCommands);
+        return validatedVoiceCommands;
     }
 
     /**

--- a/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
+++ b/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
@@ -46,6 +46,7 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
         super(lifecycleManager);
         this._voiceCommands = [];
         this._currentVoiceCommands = [];
+        this._originalVoiceCommands = [];
         this._voiceCommandIdMin = 1900000000;
         this._lastVoiceCommandId = this._voiceCommandIdMin;
         this._commandListener = null;
@@ -83,19 +84,26 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
      */
     async setVoiceCommands (voiceCommands) {
         // we actually need voice commands to set. checks if the array of voice commands passed in contains the same content as the current voice commands
-        if (!Array.isArray(voiceCommands) || !voiceCommands.map((vc, index) => vc.equals(this._voiceCommands[index])).includes(false)) {
+        if (!Array.isArray(voiceCommands) || !voiceCommands.map((vc, index) => vc.equals(this._originalVoiceCommands[index])).includes(false)) {
             console.log('Voice commands list non-existent or matches the current voice commands');
             return;
         }
 
-        this._updateIdsOnVoiceCommands(voiceCommands);
-        this._voiceCommands = voiceCommands;
+        const validatedVoiceCommands = this._removeEmptyVoiceCommands(voiceCommands);
+        if (voiceCommands.length > 0 && validatedVoiceCommands.length === 0) {
+            console.log('New voice commands are invalid, skipping...');
+            return;
+        }
+
+        this._originalVoiceCommands = voiceCommands;
+        this._voiceCommands = validatedVoiceCommands;
+        this._updateIdsOnVoiceCommands(this._voiceCommands);
 
         // add the commands to a queue to be processed later
         // clear all tasks
         this._cancelAllTasks();
 
-        this._updateOperation = new _VoiceCommandUpdateOperation(this._lifecycleManager, this._currentVoiceCommands, voiceCommands, (newVoiceCommands, errorArray) => {
+        this._updateOperation = new _VoiceCommandUpdateOperation(this._lifecycleManager, this._currentVoiceCommands, this._voiceCommands, (newVoiceCommands, errorArray) => {
             if (errorArray.length !== 0) {
                 console.log('Failed updated voice commands for the following:');
                 console.log(JSON.stringify(errorArray, null, 4)); // print like this so that the inner _parameters object shows
@@ -140,6 +148,27 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
             }
             task._oldVoiceCommands = voiceCommands;
         });
+    }
+
+    /**
+     * Remove all voice command strings consisting of just whitespace characters as the module will reject any "empty" strings.
+     * @param {VoiceCommands[]} voiceCommands - An array of VoiceCommands.
+     * @returns {VoiceCommands[]} - An array of VoiceCommands with empty VoiceCommands removed.
+     */
+    _removeEmptyVoiceCommands (voiceCommands) {
+        const validatedVoiceCommands = voiceCommands.map((voiceCommand) => {
+            const voiceCommandStrings = voiceCommand.getVoiceCommands().filter((voiceCommandString) => {
+                // filter out any whitespace characters
+                return voiceCommandString !== null && voiceCommandString !== undefined && voiceCommandString.replace(/\s/g, '').length > 0;
+            });
+            // Updates voice command strings array by only adding ones that are not empty(e.g. ', ' ', ...)
+            if (voiceCommandStrings.length > 0) {
+                return voiceCommand.setVoiceCommands(voiceCommandStrings);
+            }
+        }).filter((voiceCommand) => {
+            return voiceCommand !== undefined;
+        });
+        return Array.from(validatedVoiceCommands);
     }
 
     /**

--- a/tests/managers/screen/VoiceCommandManagerTests.js
+++ b/tests/managers/screen/VoiceCommandManagerTests.js
@@ -13,14 +13,11 @@ module.exports = async function (appClient) {
 
         const voiceCommand1 = new SDL.manager.screen.utils.VoiceCommand(['Command 1', 'Command 2'], () => {});
         const voiceCommand2 = new SDL.manager.screen.utils.VoiceCommand(['Command 3', 'Command 4'], () => {});
-<<<<<<< HEAD
         const voiceCommand3 = new SDL.manager.screen.utils.VoiceCommand(['Command 5', ' ', 'Command 6', '\t'], () => {});
         const voiceCommand4 = new SDL.manager.screen.utils.VoiceCommand(['\t'], () => {});
         const voiceCommand5 = new SDL.manager.screen.utils.VoiceCommand([''], () => {});
         const voiceCommand6 = new SDL.manager.screen.utils.VoiceCommand([], () => {});
-=======
-        const voiceCommand3 = new SDL.manager.screen.utils.VoiceCommand(['Command 1', 'Command 2', 'Command 3', 'Command 4'], () => {});
->>>>>>> develop
+        const voiceCommand7 = new SDL.manager.screen.utils.VoiceCommand(['Command 1', 'Command 2', 'Command 3', 'Command 4'], () => {});
 
         const voiceCommands = [voiceCommand1, voiceCommand2];
         const voiceCommands2 = ['Test 1', 'Test 1', 'Test 1'];
@@ -102,14 +99,19 @@ module.exports = async function (appClient) {
                 Validator.assertEquals(voiceCommandManager.getVoiceCommands().length, 1);
                 Validator.assertEquals(voiceCommandManager.getVoiceCommands()[0].getVoiceCommands().length, 2);
                 Validator.assertEquals(voiceCommandManager.getVoiceCommands()[0].getVoiceCommands(), ['Command 1', 'Command 2']);
+            });
+        });
+
         describe('when new voice commands are set and have duplicate strings in different voice commands', function () {
             beforeEach(function () {
+                // clear task queue
+                voiceCommandManager._taskQueue = [];
                 voiceCommandManager.setVoiceCommands([voiceCommand2, voiceCommand3]);
             });
 
             it('should only have one operation', function () {
                 Validator.assertEquals(voiceCommandManager._getTasks().length, 1);
-                Validator.assertTrue(!voiceCommandManager._arePendingVoiceCommandsUnique([voiceCommand2, voiceCommand3]));
+                Validator.assertTrue(!voiceCommandManager._arePendingVoiceCommandsUnique([voiceCommand2, voiceCommand7]));
             });
         });
 

--- a/tests/managers/screen/VoiceCommandManagerTests.js
+++ b/tests/managers/screen/VoiceCommandManagerTests.js
@@ -13,6 +13,10 @@ module.exports = async function (appClient) {
 
         const voiceCommand1 = new SDL.manager.screen.utils.VoiceCommand(['Command 1', 'Command 2'], () => {});
         const voiceCommand2 = new SDL.manager.screen.utils.VoiceCommand(['Command 3', 'Command 4'], () => {});
+        const voiceCommand3 = new SDL.manager.screen.utils.VoiceCommand(['Command 5', ' ', 'Command 6', '\t'], () => {});
+        const voiceCommand4 = new SDL.manager.screen.utils.VoiceCommand(['\t'], () => {});
+        const voiceCommand5 = new SDL.manager.screen.utils.VoiceCommand([''], () => {});
+        const voiceCommand6 = new SDL.manager.screen.utils.VoiceCommand([], () => {});
 
         const voiceCommands = [voiceCommand1, voiceCommand2];
 
@@ -66,6 +70,26 @@ module.exports = async function (appClient) {
 
             // verify the mock listener has been hit once
             Validator.assertEquals(callback.calledOnce, true);
+        });
+
+        describe('if any of the voice commands contains an empty string', function () {
+            it('should remove the empty strings and queue another operation', async function () {
+                await voiceCommandManager.setVoiceCommands([voiceCommand2, voiceCommand3, voiceCommand4, voiceCommand5, voiceCommand6]);
+                Validator.assertEquals(voiceCommandManager.getVoiceCommands().length, 2);
+                Validator.assertEquals(voiceCommandManager.getVoiceCommands()[0].getVoiceCommands().length, 2);
+                Validator.assertEquals(voiceCommandManager.getVoiceCommands()[0].getVoiceCommands(), ['Command 3', 'Command 4']);
+                Validator.assertEquals(voiceCommandManager.getVoiceCommands()[1].getVoiceCommands().length, 2);
+                Validator.assertEquals(voiceCommandManager.getVoiceCommands()[1].getVoiceCommands(), ['Command 5', 'Command 6']);
+            });
+
+            it('should not queue another operation if all the voice command strings are empty strings', async function () {
+                await voiceCommandManager.setVoiceCommands([voiceCommand1]);
+                // these commands are empty and should be ignored entirely
+                await voiceCommandManager.setVoiceCommands([voiceCommand4, voiceCommand5]);
+                Validator.assertEquals(voiceCommandManager.getVoiceCommands().length, 1);
+                Validator.assertEquals(voiceCommandManager.getVoiceCommands()[0].getVoiceCommands().length, 2);
+                Validator.assertEquals(voiceCommandManager.getVoiceCommands()[0].getVoiceCommands(), ['Command 1', 'Command 2']);
+            });
         });
 
         after(function () {


### PR DESCRIPTION
Fixes #431 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Changelog
##### Bug Fixes
* Removes empty voice commands from the list of voice commands to be set by the operation and does not perform an operation if there are no voice commands left.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
