### PR TITLE
Sending an empty voice command array should delete all current voice commands

### DIFF
--- a/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
+++ b/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
@@ -83,7 +83,7 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
      */
     async setVoiceCommands (voiceCommands) {
         // we actually need voice commands to set. checks if the array of voice commands passed in contains the same content as the current voice commands
-        if (!Array.isArray(voiceCommands) || !voiceCommands.map((vc, index) => vc.equals(this._voiceCommands[index])).includes(false)) {
+        if (!Array.isArray(voiceCommands) || (voiceCommands.length > 0 && !voiceCommands.map((vc, index) => vc.equals(this._voiceCommands[index])).includes(false))) {
             console.log('Voice commands list non-existent or matches the current voice commands');
             return;
         }
@@ -94,7 +94,6 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
         // add the commands to a queue to be processed later
         // clear all tasks
         this._cancelAllTasks();
-
         this._updateOperation = new _VoiceCommandUpdateOperation(this._lifecycleManager, this._currentVoiceCommands, voiceCommands, (newVoiceCommands, errorArray) => {
             if (errorArray.length !== 0) {
                 console.log('Failed updated voice commands for the following:');

--- a/tests/managers/screen/VoiceCommandManagerTests.js
+++ b/tests/managers/screen/VoiceCommandManagerTests.js
@@ -77,6 +77,16 @@ module.exports = async function (appClient) {
             Validator.assertEquals(callback.calledOnce, true);
         });
 
+        it('testEmptyVoiceCommandsShouldAddTask', async function () {
+            const callback = sinon.fake(() => {});
+            const stub = sinon.stub(voiceCommandManager, '_addTask')
+                .callsFake(callback);
+            await voiceCommandManager.setVoiceCommands([]);
+
+            Validator.assertTrue(callback.called);
+            stub.restore();
+        });
+
         after(function () {
             voiceCommandManager.dispose();
 


### PR DESCRIPTION
Fixes #440 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Changelog
##### Bug Fixes
* Setting an empty voice command array through the screen manager no longer fails and will delete all current voice commands. There are also new unit tests added to confirm the new functionality behaves as expected.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
