### PR TITLE
Include version check for checking file upload status

### DIFF
--- a/lib/js/src/manager/file/_FileManagerBase.js
+++ b/lib/js/src/manager/file/_FileManagerBase.js
@@ -33,6 +33,7 @@
 import { ListFiles } from './../../rpc/messages/ListFiles.js';
 import { DeleteFile } from './../../rpc/messages/DeleteFile.js';
 import { _SubManagerBase } from '../_SubManagerBase.js';
+import { Version } from './../../util/Version.js';
 
 class _FileManagerBase extends _SubManagerBase {
     /**
@@ -217,6 +218,14 @@ class _FileManagerBase extends _SubManagerBase {
      * @returns {Boolean} - Whether file has been uploaded to core (true) or not (false)
      */
     hasUploadedFile (sdlFile) {
+        // this method's logic is more related to the iOS library than the Java library
+        // https://github.com/smartdevicelink/sdl_ios/issues/827 - Older versions of Core had a bug where list files would cache incorrectly.
+        const rpcMsgVersion = this._lifecycleManager.getSdlMsgVersion();
+        const rpcVersion = new Version()
+            .setMajor(rpcMsgVersion.getMajorVersion())
+            .setMinor(rpcMsgVersion.getMinorVersion())
+            .setPatch(rpcMsgVersion.getPatchVersion());
+
         const filename = sdlFile.getName();
         const isPersistent = sdlFile.isPersistent();
         const remoteFiles = this._remoteFiles;
@@ -224,11 +233,18 @@ class _FileManagerBase extends _SubManagerBase {
         const isInRemoteFiles = remoteFiles.indexOf(filename) !== -1;
         const isInEphemeralFiles = ephemeralFiles.indexOf(filename) !== -1;
 
-        if (isPersistent) {
-            return isInRemoteFiles;
-        } else { // if it is not persistent it must be listed in both remote and ephemeral files.
-            return isInRemoteFiles && isInEphemeralFiles;
+        if (new Version(4, 4, 0).isNewerThan(rpcVersion) === 1) {
+            if (isPersistent) {
+                return isInRemoteFiles;
+            } else { // if it is not persistent it must be listed in both remote and ephemeral files.
+                return isInRemoteFiles && isInEphemeralFiles;
+            }
+        } else if (isInRemoteFiles) {
+            // If not connected to a system where the bug presents itself, we can trust the `remoteFileNames`
+            return true;
         }
+
+        return false;
     }
 
 

--- a/tests/managers/file/FileManagerTests.js
+++ b/tests/managers/file/FileManagerTests.js
@@ -259,6 +259,40 @@ module.exports = function (appClient) {
             sdlManager.removeRpcListener(SDL.rpc.enums.FunctionID.ListFiles, expectSuccess);
         });
 
+        it('testNonPersistentFilesOnOlderVersions', async function () {
+            const stub = sinon.stub(lifecycleManager, 'getSdlMsgVersion')
+                .callsFake(() => {
+                    return new SDL.rpc.structs.SdlMsgVersion()
+                        .setMajorVersion(4)
+                        .setMinorVersion(3);
+                });
+
+            fileManager._remoteFiles.splice(0, fileManager._remoteFiles.length);
+            fileManager._uploadedEphemeralFileNames.splice(0, fileManager._uploadedEphemeralFileNames.length);
+            fileManager._remoteFiles.push(validFile.getName());
+            const hasUploadedResult = fileManager.hasUploadedFile(validFile);
+            stub.restore();
+
+            Validator.assertTrue(!hasUploadedResult);
+        });
+
+        it('testNonPersistentFilesOnNewerVersions', async function () {
+            const stub = sinon.stub(lifecycleManager, 'getSdlMsgVersion')
+                .callsFake(() => {
+                    return new SDL.rpc.structs.SdlMsgVersion()
+                        .setMajorVersion(5)
+                        .setMinorVersion(0);
+                });
+
+            fileManager._remoteFiles.splice(0, fileManager._remoteFiles.length);
+            fileManager._uploadedEphemeralFileNames.splice(0, fileManager._uploadedEphemeralFileNames.length);
+            fileManager._remoteFiles.push(validFile.getName());
+            const hasUploadedResult = fileManager.hasUploadedFile(validFile);
+            stub.restore();
+
+            Validator.assertTrue(hasUploadedResult);
+        });
+
         it('testInvalidSdlFileInput', async function () {
             const expectSuccess = function (response) {
                 Validator.assertTrue(response.getSuccess());


### PR DESCRIPTION
Fixes #443 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Includes two new tests for checking uploaded non-persistent files, depending on the RPC version used. 

### Summary
Aligns the functionality of hasUploadedFile with the Java and iOS libraries