### PR TITLE
Update lifecycle manager to work around Sync 3 media capabilities bug

### DIFF
--- a/lib/js/src/manager/lifecycle/_LifecycleManager.js
+++ b/lib/js/src/manager/lifecycle/_LifecycleManager.js
@@ -321,7 +321,7 @@ class _LifecycleManager {
                         rpcMessage.setCorrelationId(++this._maxCorrelationId);
                     }
                     // Ford Sync bug returning incorrect display capabilities (https://github.com/smartdevicelink/sdl_javascript_suite/issues/446). Save the next desired layout type to the update capabilities when the SetDisplayLayout response is received
-                    if (rpcMessage.getFunctionName() === 'SetDisplayLayout') {
+                    if (rpcMessage.getFunctionId() === FunctionID.keyForValue(FunctionID.SetDisplayLayout)) {
                         this._lastDisplayLayoutRequestTemplate = rpcMessage.getDisplayLayout();
                     }
                     this.addRpcListener(FunctionID.valueForKey(rpcMessage.getFunctionId()), listener);
@@ -455,7 +455,7 @@ class _LifecycleManager {
      * @param {RpcMessage} rpc - an RPC Message
      */
     fixIncorrectDisplayCapabilities (rpc) {
-        if (MessageType.response === rpc.getMessageType() && rpc.getFunctionId() === 'SetDisplayLayout' &&
+        if (MessageType.response === rpc.getMessageType() && rpc.getFunctionId() === FunctionID.keyForValue(FunctionID.SetDisplayLayout) &&
                 this._initialMediaCapabilities !== null && this._lastDisplayLayoutRequestTemplate === PredefinedLayout.MEDIA) {
             rpc.setDisplayCapabilities(this._initialMediaCapabilities);
         }

--- a/lib/js/src/manager/lifecycle/_LifecycleManager.js
+++ b/lib/js/src/manager/lifecycle/_LifecycleManager.js
@@ -450,8 +450,9 @@ class _LifecycleManager {
     }
 
     /**
-     * 
-     * @param {*} setDisplayLayoutResponse 
+     * When a SetDisplayLayout response is received and the desired layout type is MEDIA, use the initial media capabilities
+     * See Ford Sync bug returning incorrect display capabilities (https://github.com/smartdevicelink/sdl_javascript_suite/issues/446).
+     * @param {RpcMessage} rpc - an RPC Message
      */
     fixIncorrectDisplayCapabilities (rpc) {
         if (MessageType.response === rpc.getMessageType() && rpc.getFunctionId() === 'SetDisplayLayout' &&

--- a/lib/js/src/manager/lifecycle/_LifecycleManager.js
+++ b/lib/js/src/manager/lifecycle/_LifecycleManager.js
@@ -43,6 +43,8 @@ import { SdlMsgVersion } from '../../rpc/structs/SdlMsgVersion.js';
 import { FunctionID } from '../../rpc/enums/FunctionID.js';
 import { _ServiceType } from '../../protocol/enums/_ServiceType.js';
 import { SystemInfo } from '../../util/SystemInfo.js';
+import { AppHMIType } from '../../rpc/enums/AppHMIType.js';
+import { PredefinedLayout } from '../../rpc/enums/PredefinedLayout.js';
 
 /**
  * This class should also be marked private and behind the SdlManager API
@@ -93,6 +95,8 @@ class _LifecycleManager {
         this._registerAppInterfaceResponse = null;
 
         this._didCheckSystemInfo = false;
+        this._lastDisplayLayoutRequestTemplate = null;
+        this._initialMediaCapabilities = null;
     }
 
     /**
@@ -162,6 +166,7 @@ class _LifecycleManager {
             return;
         }
 
+        this.fixIncorrectDisplayCapabilities(rpcMessage);
         const functionID = FunctionID.valueForKey(rpcMessage.getFunctionId()); // this is the number value
         const listenerArray = this._rpcListeners.get(functionID);
         if (Array.isArray(listenerArray)) {
@@ -315,6 +320,10 @@ class _LifecycleManager {
                     if (rpcMessage.getCorrelationId() === null || rpcMessage.getCorrelationId() === undefined) {
                         rpcMessage.setCorrelationId(++this._maxCorrelationId);
                     }
+                    // Ford Sync bug returning incorrect display capabilities (https://github.com/smartdevicelink/sdl_javascript_suite/issues/446). Save the next desired layout type to the update capabilities when the SetDisplayLayout response is received
+                    if (rpcMessage.getFunctionName() === 'SetDisplayLayout') {
+                        this._lastDisplayLayoutRequestTemplate = rpcMessage.getDisplayLayout();
+                    }
                     this.addRpcListener(FunctionID.valueForKey(rpcMessage.getFunctionId()), listener);
                     // listen for GenericResponse as well, in the case of interacting with older head units
                     this.addRpcListener(FunctionID.GenericResponse, listener);
@@ -440,6 +449,17 @@ class _LifecycleManager {
         return true;
     }
 
+    /**
+     * 
+     * @param {*} setDisplayLayoutResponse 
+     */
+    fixIncorrectDisplayCapabilities (rpc) {
+        if (MessageType.response === rpc.getMessageType() && rpc.getFunctionId() === 'SetDisplayLayout' &&
+                this._initialMediaCapabilities !== null && this._lastDisplayLayoutRequestTemplate === PredefinedLayout.MEDIA) {
+            rpc.setDisplayCapabilities(this._initialMediaCapabilities);
+        }
+    }
+
 
     /* *******************************************************************************************************
      ********************************** INTERNAL - RPC LISTENERS !! START !! *********************************
@@ -530,6 +550,9 @@ class _LifecycleManager {
                 console.warn('Disconnecting from head unit, the system info was not accepted.');
                 this.sendRpcResolve(new UnregisterAppInterface());
                 this._cleanProxy();
+            }
+            if (this._lifecycleConfig.getAppTypes().includes(AppHMIType.MEDIA)) {
+                this._initialMediaCapabilities = registerAppInterfaceResponse.getDisplayCapabilities();
             }
         }
 

--- a/tests/managers/lifecycle/LifecycleManagerTests.js
+++ b/tests/managers/lifecycle/LifecycleManagerTests.js
@@ -69,5 +69,33 @@ module.exports = function (appClient) {
 
             done();
         });
+
+        it('testFixingIncorrectCapabilities', function (done) {
+            let setDisplayLayoutResponse;
+
+            const registerAppInterFaceCapabilities = new SDL.rpc.structs.DisplayCapabilities()
+                .setImageFields([new SDL.rpc.structs.ImageField(SDL.rpc.enums.ImageFieldName.graphic, [SDL.rpc.enums.FileType.GRAPHIC_PNG])]);
+
+            const setDisplayLayoutCapabilities = new SDL.rpc.structs.DisplayCapabilities()
+                .setImageFields([]);
+
+            sdlManager._lifecycleManager._initialMediaCapabilities = registerAppInterFaceCapabilities;
+
+
+            // Test switching to MEDIA template - Capabilities in setDisplayLayoutResponse should be replaced with the ones from RAIR
+            sdlManager._lifecycleManager._lastDisplayLayoutRequestTemplate = SDL.rpc.enums.PredefinedLayout.MEDIA;
+            setDisplayLayoutResponse = new SDL.rpc.messages.SetDisplayLayoutResponse()
+                .setDisplayCapabilities(setDisplayLayoutCapabilities);
+            sdlManager._lifecycleManager.fixIncorrectDisplayCapabilities(setDisplayLayoutResponse);
+            Validator.assertEquals(registerAppInterFaceCapabilities, setDisplayLayoutResponse.getDisplayCapabilities());
+
+            // Test switching to non-MEDIA template - Capabilities in setDisplayLayoutResponse should not be altered
+            sdlManager._lifecycleManager._lastDisplayLayoutRequestTemplate = SDL.rpc.enums.PredefinedLayout.TEXT_WITH_GRAPHIC;
+            setDisplayLayoutResponse = new SDL.rpc.messages.SetDisplayLayoutResponse()
+                .setDisplayCapabilities(setDisplayLayoutCapabilities);
+            sdlManager._lifecycleManager.fixIncorrectDisplayCapabilities(setDisplayLayoutResponse);
+            Validator.assertEquals(setDisplayLayoutCapabilities, setDisplayLayoutResponse.getDisplayCapabilities());
+            done();
+        });
     });
 };


### PR DESCRIPTION
Fixes #446 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
[Describe the unit tests and behaviors added in this PR]

### Changelog
##### Bug Fixes
* Updates the lifecycle manager to save the initial display capabilities for type MEDIA for future use as a workaround for a Sync 3 media capabilities bug.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
