### PR TITLE
Fix case where head unit uses incorrect name for PredefinedLayout NON-MEDIA

### DIFF
--- a/lib/js/src/manager/SystemCapabilityManager.js
+++ b/lib/js/src/manager/SystemCapabilityManager.js
@@ -732,7 +732,16 @@ class SystemCapabilityManager extends _SubManagerBase {
         if (defaultMainWindow.getImageFields() !== null && defaultMainWindow.getImageFields() !== undefined) {
             convertedCapabilities.setImageFields(defaultMainWindow.getImageFields());
         }
-        convertedCapabilities.setTemplatesAvailable(defaultMainWindow.getTemplatesAvailable());
+
+        // Ford Sync bug returning incorrect template name for "NON-MEDIA" https://github.com/smartdevicelink/sdl_javascript_suite/issues/450
+        const templatesAvailable = defaultMainWindow.getTemplatesAvailable();
+        for (let index = 0; index < templatesAvailable.length; index++) {
+            if (templatesAvailable[index] === 'NON_MEDIA') {
+                templatesAvailable[index] = 'NON-MEDIA';
+                break;
+            }
+        }
+        convertedCapabilities.setTemplatesAvailable(templatesAvailable);
         convertedCapabilities.setNumCustomPresetsAvailable(defaultMainWindow.getNumCustomPresetsAvailable());
         convertedCapabilities.setMediaClockFormats([]); // mandatory field but allows empty array
         // if there are imageTypes in the response, we must assume graphics are supported


### PR DESCRIPTION
Fixes #450 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
If display capabilities uses the incorrect string 'NON_MEDIA' in templatesAvailable, it will be fixed to the correct string 'NON-MEDIA'.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
