### PR TITLE
Do a null check for the templates available in the window capability

### DIFF
--- a/lib/js/src/manager/SystemCapabilityManager.js
+++ b/lib/js/src/manager/SystemCapabilityManager.js
@@ -734,7 +734,7 @@ class SystemCapabilityManager extends _SubManagerBase {
         }
 
         // Ford Sync bug returning incorrect template name for "NON-MEDIA" https://github.com/smartdevicelink/sdl_javascript_suite/issues/450
-        const templatesAvailable = defaultMainWindow.getTemplatesAvailable();
+        const templatesAvailable = defaultMainWindow.getTemplatesAvailable() !== null ? defaultMainWindow.getTemplatesAvailable() : [];
         for (let index = 0; index < templatesAvailable.length; index++) {
             if (templatesAvailable[index] === 'NON_MEDIA') {
                 templatesAvailable[index] = 'NON-MEDIA';


### PR DESCRIPTION
Fixes #465 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Adds a null check to getting available templates in one of the SCM's methods to prevent a reference error.
