### PR TITLE
Don't add choice cells to list of preloaded cells if they failed to preload

### DIFF
--- a/lib/js/src/manager/screen/choiceset/_ChoiceSetManagerBase.js
+++ b/lib/js/src/manager/screen/choiceset/_ChoiceSetManagerBase.js
@@ -153,14 +153,16 @@ class _ChoiceSetManagerBase extends _SubManagerBase {
         }
         return new Promise(resolve => {
             const preloadChoicesOperation = new _PreloadChoicesOperation(this._lifecycleManager, this._fileManager,
-                this._displayName, this._defaultMainWindowCapability, this._isVrOptional, choicesToUpload, success => {
-                    if (!success) {
-                        console.error('ChoiceSetManager: There was an error preloading choice cells');
-                        return resolve(false);
+                this._displayName, this._defaultMainWindowCapability, this._isVrOptional, choicesToUpload, (success, failedChoiceCells) => {
+                    if (success) {
+                        this._preloadedChoices = this._preloadedChoices.concat(choicesToUpload);
+                        this._removeChoicesFromChoices(choicesToUpload, this._pendingPreloadChoices);
+                    } else {
+                        this._removeChoicesFromChoices(failedChoiceCells, choicesToUpload);
+                        this._preloadedChoices = this._preloadedChoices.concat(choicesToUpload);
+                        this._removeChoicesFromChoices(choicesToUpload, this._pendingPreloadChoices);
                     }
-                    this._preloadedChoices = this._preloadedChoices.concat(choicesToUpload);
-                    this._removeChoicesFromChoices(choicesToUpload, this._pendingPreloadChoices);
-                    resolve(true);
+                    resolve(success);
                 });
             this._addTask(preloadChoicesOperation);
         });

--- a/lib/js/src/manager/screen/choiceset/_PreloadChoicesOperation.js
+++ b/lib/js/src/manager/screen/choiceset/_PreloadChoicesOperation.js
@@ -60,6 +60,7 @@ class _PreloadChoicesOperation extends _Task {
         this._isVrOptional = isVrOptional;
         this._cellsToPreload = cellsToPreload;
         this._completionListener = completionListener;
+        this._failedChoiceCells = [];
         // internal usage
         this._isRunning = false;
     }
@@ -126,13 +127,13 @@ class _PreloadChoicesOperation extends _Task {
 
         if (cicsRpcs.length === 0) {
             console.error('PreloadChoicesOperation: All Choice cells to send are null, so the choice set will not be shown');
-            this._completionListener(true);
+            this._completionListener(true, null);
             return;
         }
 
         if (this._lifecycleManager === null) {
             console.error('PreloadChoicesOperation: The LifecycleManager is null');
-            this._completionListener(false);
+            this._completionListener(false, this._cellsToPreload);
             return;
         }
 
@@ -147,11 +148,17 @@ class _PreloadChoicesOperation extends _Task {
             const response = responses[index];
             if (!response.getSuccess()) {
                 allSucceeded = false;
+                const choiceId = cicsRpcs[index].getChoiceSet()[0].getChoiceID();
+                for (const cell of this._cellsToPreload) {
+                    if (cell._getChoiceId() === choiceId) {
+                        this._failedChoiceCells.push(cell);
+                    }
+                }
                 console.error(`PreloadChoicesOperation: There was an error uploading a choice cell: ${response.getInfo()} | resultCode: ${response.getResultCode()}`);
             }
         }
         // report whether all succeeded
-        this._completionListener(allSucceeded);
+        this._completionListener(allSucceeded, this._failedChoiceCells);
     }
 
     /**


### PR DESCRIPTION
Fixes #470 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
This PR updates the ChoiceSet Manager to handle failures individually when preloading ChoiceCells. Successful choices will be added to the list of preloaded cells but failed cells will not be added.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
