### PR TITLE
Fix submanager to invoke the task queue when changing the system context

### DIFF
--- a/lib/js/src/manager/_SubManagerBase.js
+++ b/lib/js/src/manager/_SubManagerBase.js
@@ -217,6 +217,7 @@ class _SubManagerBase {
                 }
                 if (this._currentSystemContext === SystemContext.SYSCTXT_MAIN && this._currentHmiLevel !== HMILevel.HMI_NONE) {
                     this._canRunTasks = true;
+                    this._invokeTaskQueue();
                 }
             }
         };


### PR DESCRIPTION
Fixes #472 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Fixes the case where on an OnHmiStatus SystemContext change, the SubManagerBase is able to run tasks again but does not immediately restart the task queue. This would leave some tasks idle in the queue until another task was added.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
