### PR TITLE
Add invokeTaskQueue to SoftButtonManager

### DIFF
--- a/lib/js/src/manager/screen/_SoftButtonManagerBase.js
+++ b/lib/js/src/manager/screen/_SoftButtonManagerBase.js
@@ -187,6 +187,7 @@ class _SoftButtonManagerBase extends _SubManagerBase {
         } else if (!this._canRunTasks) { // helps reduces console log spam
             console.log('SoftButtonManagerBase - Starting the transaction queue');
             this._canRunTasks = true;
+            this._invokeTaskQueue();
         }
     }
 


### PR DESCRIPTION
Fixes #485 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Adds an invocation to the task queue after tasks are able to run again in the SoftButtonManager. See MenuManager's same named method for comparison.