### PR TITLE
Fix boolean return in _preloadCellArtworks

### DIFF
--- a/lib/js/src/manager/screen/choiceset/_PreloadPresentChoicesOperation.js
+++ b/lib/js/src/manager/screen/choiceset/_PreloadPresentChoicesOperation.js
@@ -468,7 +468,7 @@ class _PreloadPresentChoicesOperation extends _Task {
             console.error('PreloadChoicesOperation: Error uploading choice cell artworks');
         }
 
-        return uploadResults.includes(false);
+        return !uploadResults.includes(false);
     }
 
     /**


### PR DESCRIPTION
Fixes #495 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Change the return value of _preloadCellArtworks to be correct