### PR TITLE
Make detaching listener happen all the time in finishOperation

### DIFF
--- a/lib/js/src/manager/screen/choiceset/_PreloadPresentChoicesOperation.js
+++ b/lib/js/src/manager/screen/choiceset/_PreloadPresentChoicesOperation.js
@@ -703,6 +703,9 @@ class _PreloadPresentChoicesOperation extends _Task {
             this._completionListener(this._loadedCells, success);
         }
 
+        // detach the OnKeyboardInput listener at the end
+        this._lifecycleManager.removeRpcListener(FunctionID.OnKeyboardInput, this._keyboardRpcListener);
+
         if (this._lifecycleManager === null) {
             console.error('PresentChoiceSetOperation: LifecycleManager is null');
             this._currentState = _PreloadPresentChoicesOperationState.FINISHING;
@@ -716,8 +719,6 @@ class _PreloadPresentChoicesOperation extends _Task {
             const setGlobalProperties = new SetGlobalProperties()
                 .setKeyboardProperties(this._originalKeyboardProperties);
 
-            // detach the OnKeyboardInput listener at the end
-            this._lifecycleManager.removeRpcListener(FunctionID.OnKeyboardInput, this._keyboardRpcListener);
             const response = await this._lifecycleManager.sendRpcResolve(setGlobalProperties);
 
             if (response.getSuccess()) {

--- a/lib/js/src/manager/screen/choiceset/_PreloadPresentChoicesOperation.js
+++ b/lib/js/src/manager/screen/choiceset/_PreloadPresentChoicesOperation.js
@@ -703,15 +703,15 @@ class _PreloadPresentChoicesOperation extends _Task {
             this._completionListener(this._loadedCells, success);
         }
 
-        // detach the OnKeyboardInput listener at the end
-        this._lifecycleManager.removeRpcListener(FunctionID.OnKeyboardInput, this._keyboardRpcListener);
-
         if (this._lifecycleManager === null) {
             console.error('PresentChoiceSetOperation: LifecycleManager is null');
             this._currentState = _PreloadPresentChoicesOperationState.FINISHING;
             this.onFinished();
             return;
         }
+
+        // detach the OnKeyboardInput listener at the end
+        this._lifecycleManager.removeRpcListener(FunctionID.OnKeyboardInput, this._keyboardRpcListener);
 
         if (this._updatedKeyboardProperties) {
             this._currentState = _PreloadPresentChoicesOperationState.RESETTING_KEYBOARD_PROPERTIES;


### PR DESCRIPTION
Fixes #497 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Moves the teardown of the keyboard listener to the beginning of the finishOperation to prevent hanging listeners from continuing to function after the operation ends.