### PR TITLE
Initialize button ID sets on connection

### DIFF
--- a/lib/js/src/manager/screen/_ScreenManagerBase.js
+++ b/lib/js/src/manager/screen/_ScreenManagerBase.js
@@ -77,6 +77,10 @@ class _ScreenManagerBase extends _SubManagerBase {
             this._choiceSetManagerBase.start(),
             this._menuManagerBase.start(),
         ]);
+
+        _ScreenManagerBase._softButtonIDBySoftButtonManager = new Set();
+        _ScreenManagerBase._softButtonIDByAlertManager = new Set();
+
         this._transitionToState(_SubManagerBase.READY);
         await super.start();
     }
@@ -742,9 +746,6 @@ _ManagerLocation._MAP = Object.freeze({
 });
 
 _ScreenManagerBase._ManagerLocation = _ManagerLocation;
-
-_ScreenManagerBase._softButtonIDBySoftButtonManager = new Set();
-_ScreenManagerBase._softButtonIDByAlertManager = new Set();
 
 const SOFT_BUTTON_ID_NOT_SET_VALUE = -1;
 const SOFT_BUTTON_ID_MIN_VALUE = 0;


### PR DESCRIPTION
Fixes #501 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Tested against Manticore v2.8.0.

### Summary
This PR updates the ScreenManager to reinitialize its Sets of button IDs upon connection. This prevents the case where disconnecting and reconnecting would cause an error.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
