### PR TITLE
Log warning when trying to send a SubMenu cell with voice commands

### DIFF
--- a/lib/js/src/manager/screen/menu/_MenuReplaceUtilities.js
+++ b/lib/js/src/manager/screen/menu/_MenuReplaceUtilities.js
@@ -342,7 +342,7 @@ class _MenuReplaceUtilities {
         const shouldCellIncludeSecondaryImage = cell.getSecondaryArtwork() !== null && cell.getSecondaryArtwork().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludeSecondaryImageFromCell(cell, fileManager, windowCapability);
         const secondaryIcon = shouldCellIncludeSecondaryImage ? cell.getSecondaryArtwork().getImageRPC() : null;
 
-        if (cell.getVoiceCommands() !== null) {
+        if (Array.isArray(cell.getVoiceCommands()) && cell.getVoiceCommands().length > 0) {
             console.warn('MenuManagerBase - Setting voice commands for submenu cells is not supported. The voice commands will not be set.');
         }
 


### PR DESCRIPTION
Fixes #504 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
This PR adds a warning message for when the developer tries to send a MenuCell with SubCells and voice commands, because the AddSubMenu RPC does not support voice commands

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
