### PR TITLE
Fix AlertManager logic for canceling an in-progress alert

### DIFF
--- a/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
+++ b/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
@@ -258,7 +258,7 @@ class _PresentAlertOperation extends _Task {
      */
     async cancelAlert () {
         if (this.getState() === _Task.FINISHED) {
-            console.logInfo('This operation has already finished so it can not be canceled');
+            console.log('This operation has already finished so it can not be canceled');
             return;
         } else if (this.getState() === _Task.CANCELED) {
             console.log('This operation has already been canceled. It will be finished at some point during the operation.');


### PR DESCRIPTION
Fixes #509 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
This PR fixes the _PresentAlertOperation's canceledListener to not change the context of `this`. This PR also sets the canceledListener for the original AlertView as well as the cloned object.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
