### PR TITLE
Bugfix/menu manager version images

### DIFF
--- a/lib/js/src/manager/screen/menu/_MenuReplaceOperation.js
+++ b/lib/js/src/manager/screen/menu/_MenuReplaceOperation.js
@@ -402,11 +402,14 @@ class _MenuReplaceOperation extends _Task {
             // Strip away fields that cannot be used to determine uniqueness visually including fields not supported by the HMI
             cell.setVoiceCommands(null);
 
-            // Don't check ImageFieldName.subMenuIcon because it was added in 7.0 when the feature was added in 5.0.
-            // Just assume that if cmdIcon is not available, the submenu icon is not either.
-            if (!_ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.cmdIcon)) {
+            if (!_MenuReplaceUtilities.windowCapabilitySupportsPrimaryImage(this._lifecycleManager, windowCapability, cell)) {
                 cell.setIcon(null);
             }
+
+            if (!_MenuReplaceUtilities.windowCapabilitySupportsSecondaryImage(windowCapability, cell)) {
+                cell.setSecondaryArtwork(null);
+            }
+
             // Check for subMenu fields supported
             if (cell.isSubMenuCell()) {
                 if (!_ManagerUtility.hasTextFieldOfName(windowCapability, TextFieldName.menuSubMenuSecondaryText)) {
@@ -415,9 +418,6 @@ class _MenuReplaceOperation extends _Task {
                 if (!_ManagerUtility.hasTextFieldOfName(windowCapability, TextFieldName.menuSubMenuTertiaryText)) {
                     cell.setTertiaryText(null);
                 }
-                if (!_ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.menuSubMenuSecondaryImage)) {
-                    cell.setSecondaryArtwork(null);
-                }
                 cell.setSubCells(this._cellsWithRemovedPropertiesFromCells(cell.getSubCells(), windowCapability));
             } else {
                 if (!_ManagerUtility.hasTextFieldOfName(windowCapability, TextFieldName.menuCommandSecondaryText)) {
@@ -425,9 +425,6 @@ class _MenuReplaceOperation extends _Task {
                 }
                 if (!_ManagerUtility.hasTextFieldOfName(windowCapability, TextFieldName.menuCommandTertiaryText)) {
                     cell.setTertiaryText(null);
-                }
-                if (!_ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.menuCommandSecondaryImage)) {
-                    cell.setSecondaryArtwork(null);
                 }
             }
         });

--- a/lib/js/src/manager/screen/menu/_MenuReplaceOperation.js
+++ b/lib/js/src/manager/screen/menu/_MenuReplaceOperation.js
@@ -35,7 +35,6 @@ import { _DynamicMenuUpdateAlgorithm } from './_DynamicMenuUpdateAlgorithm';
 import { _MenuReplaceUtilities } from './_MenuReplaceUtilities';
 import { _MenuCellState } from './enums/_MenuCellState';
 import { _ManagerUtility } from '../../_ManagerUtility.js';
-import { ImageFieldName } from '../../../rpc/enums/ImageFieldName.js';
 import { TextFieldName } from '../../../rpc/enums/TextFieldName.js';
 import { _MenuManagerBase } from './_MenuManagerBase';
 

--- a/lib/js/src/manager/screen/menu/_MenuReplaceOperation.js
+++ b/lib/js/src/manager/screen/menu/_MenuReplaceOperation.js
@@ -159,7 +159,7 @@ class _MenuReplaceOperation extends _Task {
      * @returns {Promise} - A promise resolving to a boolean as to whether the operation succeeded
      */
     async _uploadMenuArtworks () {
-        const artworksToBeUploaded = _MenuReplaceUtilities.findAllArtworksToBeUploadedFromCells(this._updatedMenu, this._fileManager, this._windowCapability);
+        const artworksToBeUploaded = _MenuReplaceUtilities.findAllArtworksToBeUploadedFromCells(this._lifecycleManager, this._updatedMenu, this._fileManager, this._windowCapability);
         if (artworksToBeUploaded.length === 0) {
             return true;
         }
@@ -301,9 +301,9 @@ class _MenuReplaceOperation extends _Task {
 
         const defaultSubmenuLayout = this._menuConfiguration !== null ? this._menuConfiguration.getSubMenuLayout() : null;
         // RPCs for cells on the main menu level. They could be AddCommands or AddSubMenus depending on whether the cell has child cells or not.
-        const mainMenuCommands = _MenuReplaceUtilities.mainMenuCommandsForCells(addMenuCells, this._fileManager, fullMenu, this._windowCapability, defaultSubmenuLayout);
+        const mainMenuCommands = _MenuReplaceUtilities.mainMenuCommandsForCells(this._lifecycleManager, addMenuCells, this._fileManager, fullMenu, this._windowCapability, defaultSubmenuLayout);
         // RPCs for cells on the second menu level (one level deep). They could be AddCommands or AddSubMenus.
-        const subMenuCommands = _MenuReplaceUtilities.subMenuCommandsForCells(addMenuCells, this._fileManager, this._windowCapability, defaultSubmenuLayout);
+        const subMenuCommands = _MenuReplaceUtilities.subMenuCommandsForCells(this._lifecycleManager, addMenuCells, this._fileManager, this._windowCapability, defaultSubmenuLayout);
         // the main menu commands and submenu commands could be combined into one list to reduce line code waste
         const errorArrayMain = [];
 

--- a/lib/js/src/manager/screen/menu/_MenuReplaceUtilities.js
+++ b/lib/js/src/manager/screen/menu/_MenuReplaceUtilities.js
@@ -37,8 +37,8 @@ import { AddSubMenu } from '../../../rpc/messages/AddSubMenu.js';
 import { DeleteCommand } from '../../../rpc/messages/DeleteCommand.js';
 import { DeleteSubMenu } from '../../../rpc/messages/DeleteSubMenu.js';
 import { MenuParams } from '../../../rpc/structs/MenuParams.js';
+import { Version } from '../../../util/Version';
 import { _MenuManagerBase } from './_MenuManagerBase.js';
-
 
 class _MenuReplaceUtilities {
     /**
@@ -105,13 +105,14 @@ class _MenuReplaceUtilities {
 
     /**
      * Finds artworks in menu cells that need uploading
+     * @param {_LifecycleManager} lifecycleManager - A _LifecycleManager instance
      * @param {MenuCell[]} cells - The menu cell list
      * @param {FileManager} fileManager - Filemanager for checking artwork uploading
      * @param {WindowCapability} windowCapability - What the HMI is capable of
      * @param {SdlArtwork[]} uniqueArtworksToUpload - The currently found, unique artworks
      * @returns {SdlArtwork[]} - The found artworks
      */
-    static findAllArtworksToBeUploadedFromCells (cells, fileManager = null, windowCapability, uniqueArtworksToUpload = []) {
+    static findAllArtworksToBeUploadedFromCells (lifecycleManager, cells, fileManager = null, windowCapability, uniqueArtworksToUpload = []) {
         // Make sure we can use images in the menus
         if (!_ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.cmdIcon)) {
             return [];
@@ -119,16 +120,16 @@ class _MenuReplaceUtilities {
 
         cells.forEach(cell => {
             if (fileManager !== null) {
-                if (fileManager.fileNeedsUpload(cell.getIcon())) {
+                if (_MenuReplaceUtilities.windowCapabilitySupportsPrimaryImage(lifecycleManager, windowCapability, cell) && fileManager.fileNeedsUpload(cell.getIcon())) {
                     artworkUniquenessCheck(cell.getIcon());
                 }
-                if (_ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.menuCommandSecondaryImage) && fileManager.fileNeedsUpload(cell.getSecondaryArtwork())) {
+                if (_MenuReplaceUtilities.windowCapabilitySupportsSecondaryImage(windowCapability, cell) && fileManager.fileNeedsUpload(cell.getSecondaryArtwork())) {
                     artworkUniquenessCheck(cell.getSecondaryArtwork());
                 }
             }
             if (cell.isSubMenuCell() && cell.getSubCells().length !== 0) {
                 // pass along the currently found unique artworks in recursive calls to prevent duplicate artworks from subcells
-                uniqueArtworksToUpload = _MenuReplaceUtilities.findAllArtworksToBeUploadedFromCells(cell.getSubCells(), fileManager, windowCapability, uniqueArtworksToUpload);
+                uniqueArtworksToUpload = _MenuReplaceUtilities.findAllArtworksToBeUploadedFromCells(lifecycleManager, cell.getSubCells(), fileManager, windowCapability, uniqueArtworksToUpload);
             }
         });
 
@@ -149,26 +150,61 @@ class _MenuReplaceUtilities {
     }
 
     /**
+     * Checks whether the window capability has primary images supported
+     * @param {_LifecycleManager} lifecycleManager - A _LifecycleManager instance
+     * @param {WindowCapability} windowCapability - What the HMI is capable of
+     * @param {MenuCell} cell - The menu cell to check
+     * @returns {Boolean} - Whether the capability is supported
+     */
+    static windowCapabilitySupportsPrimaryImage (lifecycleManager = null, windowCapability, cell) {
+        if (cell.isSubMenuCell() && lifecycleManager !== null && lifecycleManager.getSdlMsgVersion() !== null) {
+            const headUnitRpcVersion = new Version(lifecycleManager.getSdlMsgVersion());
+            const minRpcVersion = new Version(5, 0, 0);
+            const maxRpcVersion = new Version(7, 1, 0);
+            // If RPC version is >= 5.0 && < 7.1
+            if (headUnitRpcVersion.isNewerThan(minRpcVersion) === 0 || headUnitRpcVersion.isBetween(minRpcVersion, maxRpcVersion) === 1) {
+                return true;
+            } else {
+                return _ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.subMenuIcon);
+            }
+        } else {
+            return _ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.cmdIcon);
+        }
+    }
+
+    /**
+     * Checks whether the window capability has secondary images supported
+     * @param {WindowCapability} windowCapability - What the HMI is capable of
+     * @param {MenuCell} cell - The menu cell to check
+     * @returns {Boolean} - Whether the capability is supported
+     */
+    static windowCapabilitySupportsSecondaryImage (windowCapability, cell) {
+        return cell.isSubMenuCell() ? _ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.menuSubMenuSecondaryImage) : _ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.menuCommandSecondaryImage);
+    }
+
+    /**
      * If there is an icon and the icon has been uploaded, or if the icon is a static icon, it should include the primary image
+     * @param {_LifecycleManager} lifecycleManager - A _LifecycleManager instance
      * @param {MenuCell} cell - The menu cell to check
      * @param {FileManager} fileManager - Filemanager for checking artwork uploading
      * @param {WindowCapability} windowCapability - What the HMI is capable of
      * @returns {Boolean} - Whether a cell should include the primary image
      */
-    static shouldCellIncludePrimaryImageFromCell (cell, fileManager, windowCapability) {
-        const supportsImage = cell.isSubMenuCell() ? _ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.subMenuIcon) : _ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.cmdIcon);
+    static shouldCellIncludePrimaryImageFromCell (lifecycleManager, cell, fileManager, windowCapability) {
+        const supportsImage = _MenuReplaceUtilities.windowCapabilitySupportsPrimaryImage(lifecycleManager, windowCapability, cell);
         return cell.getIcon() !== null && supportsImage && (fileManager.hasUploadedFile(cell.getIcon()) || cell.getIcon().isStaticIcon());
     }
 
     /**
      * If there is an icon and the icon has been uploaded, or if the icon is a static icon, it should include the secondary image
+     * @param {_LifecycleManager} lifecycleManager - A _LifecycleManager instance
      * @param {MenuCell} cell - The menu cell to check
      * @param {FileManager} fileManager - Filemanager for checking artwork uploading
      * @param {WindowCapability} windowCapability - What the HMI is capable of
      * @returns {Boolean} - Whether a cell should include the secondary image
      */
-    static shouldCellIncludeSecondaryImageFromCell (cell, fileManager, windowCapability) {
-        const supportsImage = cell.isSubMenuCell() ? _ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.menuSubMenuSecondaryImage) : _ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.menuCommandSecondaryImage);
+    static shouldCellIncludeSecondaryImageFromCell (lifecycleManager, cell, fileManager, windowCapability) {
+        const supportsImage = _MenuReplaceUtilities.windowCapabilitySupportsSecondaryImage(windowCapability, cell);
         return cell.getSecondaryArtwork() !== null && supportsImage && (fileManager.hasUploadedFile(cell.getSecondaryArtwork()) || cell.getSecondaryArtwork().isStaticIcon());
     }
 
@@ -223,6 +259,7 @@ class _MenuReplaceUtilities {
 
     /**
      * Takes all menu cells in the cells parameter that exist in the menu parameter and makes add requests for the cells' contents
+     * @param {_LifecycleManager} lifecycleManager - A _LifecycleManager instance
      * @param {MenuCell[]} cells - The cells to analyze and add
      * @param {FileManager} fileManager - The file manager
      * @param {MenuCell[]} menu - The cells to compare with the cells parameter
@@ -230,7 +267,7 @@ class _MenuReplaceUtilities {
      * @param {MenuLayout} defaultSubmenuLayout - The default MenuLayout
      * @returns {RpcRequest[]} - An array of AddCommand and AddSubMenu requests
      */
-    static mainMenuCommandsForCells (cells, fileManager, menu, windowCapability, defaultSubmenuLayout) {
+    static mainMenuCommandsForCells (lifecycleManager, cells, fileManager, menu, windowCapability, defaultSubmenuLayout) {
         const commands = [];
         // We need the index to use it as a position
         for (let menuInteger = 0; menuInteger < menu.length; menuInteger++) {
@@ -239,9 +276,9 @@ class _MenuReplaceUtilities {
                 const addCell = cells[updateCellsIndex];
                 if (mainCell.equals(addCell)) {
                     if (addCell.isSubMenuCell()) {
-                        commands.push(_MenuReplaceUtilities.subMenuCommandForMenuCell(addCell, fileManager, windowCapability, menuInteger, defaultSubmenuLayout));
+                        commands.push(_MenuReplaceUtilities.subMenuCommandForMenuCell(lifecycleManager, addCell, fileManager, windowCapability, menuInteger, defaultSubmenuLayout));
                     } else {
-                        commands.push(_MenuReplaceUtilities.commandForMenuCell(addCell, fileManager, windowCapability, menuInteger));
+                        commands.push(_MenuReplaceUtilities.commandForMenuCell(lifecycleManager, addCell, fileManager, windowCapability, menuInteger));
                     }
                     break;
                 }
@@ -252,17 +289,18 @@ class _MenuReplaceUtilities {
 
     /**
      * Goes through menu cells and creates add commands that would create the structure of the menu cells
+     * @param {_LifecycleManager} lifecycleManager - A _LifecycleManager instance
      * @param {MenuCell[]} cells - The cells to analyze and add
      * @param {FileManager} fileManager - The file manager
      * @param {WindowCapability} windowCapability - The window capabilities
      * @param {MenuLayout} defaultSubmenuLayout - The default MenuLayout
      * @returns {RpcRequest[]} - An array of AddCommand and AddSubMenu requests based on the cells
      */
-    static subMenuCommandsForCells (cells, fileManager, windowCapability, defaultSubmenuLayout) {
+    static subMenuCommandsForCells (lifecycleManager, cells, fileManager, windowCapability, defaultSubmenuLayout) {
         let commands = [];
         cells.forEach(cell => {
             if (cell.isSubMenuCell() && cell.getSubCells().length !== 0) {
-                commands = commands.concat(_MenuReplaceUtilities.allCommandsForCells(cell.getSubCells(), fileManager, windowCapability, defaultSubmenuLayout));
+                commands = commands.concat(_MenuReplaceUtilities.allCommandsForCells(lifecycleManager, cell.getSubCells(), fileManager, windowCapability, defaultSubmenuLayout));
             }
         });
         return commands;
@@ -270,25 +308,26 @@ class _MenuReplaceUtilities {
 
     /**
      * Goes through menu cells recursively and creates add commands that would create the structure of the menu cells
+     * @param {_LifecycleManager} lifecycleManager - A _LifecycleManager instance
      * @param {MenuCell[]} cells - The cells to analyze and add
      * @param {FileManager} fileManager - The file manager
      * @param {WindowCapability} windowCapability - The window capabilities
      * @param {MenuLayout} defaultSubmenuLayout - The default MenuLayout
      * @returns {RpcRequest[]} - An array of AddCommand and AddSubMenu requests based on the cells
      */
-    static allCommandsForCells (cells, fileManager, windowCapability, defaultSubmenuLayout) {
+    static allCommandsForCells (lifecycleManager, cells, fileManager, windowCapability, defaultSubmenuLayout) {
         let commands = [];
 
         for (let cellIndex = 0; cellIndex < cells.length; cellIndex++) {
             const cell = cells[cellIndex];
             if (cell.isSubMenuCell()) {
-                commands.push(_MenuReplaceUtilities.subMenuCommandForMenuCell(cell, fileManager, windowCapability, cellIndex, defaultSubmenuLayout));
+                commands.push(_MenuReplaceUtilities.subMenuCommandForMenuCell(lifecycleManager, cell, fileManager, windowCapability, cellIndex, defaultSubmenuLayout));
                 // recursively grab the commands for all the sub cells
                 if (cell.getSubCells().length !== 0) {
-                    commands = commands.concat(_MenuReplaceUtilities.allCommandsForCells(cell.getSubCells(), fileManager, windowCapability, defaultSubmenuLayout));
+                    commands = commands.concat(_MenuReplaceUtilities.allCommandsForCells(lifecycleManager, cell.getSubCells(), fileManager, windowCapability, defaultSubmenuLayout));
                 }
             } else {
-                commands.push(_MenuReplaceUtilities.commandForMenuCell(cell, fileManager, windowCapability, cellIndex));
+                commands.push(_MenuReplaceUtilities.commandForMenuCell(lifecycleManager, cell, fileManager, windowCapability, cellIndex));
             }
         }
         return commands;
@@ -296,13 +335,14 @@ class _MenuReplaceUtilities {
 
     /**
      * Creates an AddCommand based on the menu cell
+     * @param {_LifecycleManager} lifecycleManager - A _LifecycleManager instance
      * @param {MenuCell} cell - The cell to use to make an AddCommand
      * @param {FileManager} fileManager - The file manager
      * @param {WindowCapability} windowCapability - The window capabilities
      * @param {Number} position - The position of the menu item
      * @returns {AddCommand} - The created AddCommand
      */
-    static commandForMenuCell (cell, fileManager, windowCapability, position) {
+    static commandForMenuCell (lifecycleManager, cell, fileManager, windowCapability, position) {
         const command = new AddCommand().setCmdID(cell._getCellId());
         const params = new MenuParams().setMenuName(cell._getUniqueTitle());
         params.setSecondaryText(cell.getSecondaryText() !== null && cell.getSecondaryText().length !== 0 && _ManagerUtility.hasTextFieldOfName(windowCapability, TextFieldName.menuCommandSecondaryText) ? cell.getSecondaryText() : null);
@@ -318,10 +358,10 @@ class _MenuReplaceUtilities {
         }
 
         // this line is made to be the same as in subMenuCommandForMenuCell
-        const shouldCellIncludePrimaryImage = cell.getIcon() !== null && cell.getIcon().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludePrimaryImageFromCell(cell, fileManager, windowCapability);
+        const shouldCellIncludePrimaryImage = cell.getIcon() !== null && cell.getIcon().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludePrimaryImageFromCell(lifecycleManager, cell, fileManager, windowCapability);
         command.setCmdIcon(shouldCellIncludePrimaryImage ? cell.getIcon().getImageRPC() : null);
 
-        const shouldCellIncludeSecondaryImage = cell.getSecondaryArtwork() !== null && cell.getSecondaryArtwork().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludeSecondaryImageFromCell(cell, fileManager, windowCapability);
+        const shouldCellIncludeSecondaryImage = cell.getSecondaryArtwork() !== null && cell.getSecondaryArtwork().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludeSecondaryImageFromCell(lifecycleManager, cell, fileManager, windowCapability);
         command.setSecondaryImage(shouldCellIncludeSecondaryImage ? cell.getSecondaryArtwork().getImageRPC() : null);
 
         return command;
@@ -329,6 +369,7 @@ class _MenuReplaceUtilities {
 
     /**
      * Creates an AddSubMenu based on the menu cell
+     * @param {_LifecycleManager} lifecycleManager - A _LifecycleManager instance
      * @param {MenuCell} cell - The cell to use to make an AddSubMenu
      * @param {FileManager} fileManager - The file manager
      * @param {WindowCapability} windowCapability - The window capabilities
@@ -336,10 +377,10 @@ class _MenuReplaceUtilities {
      * @param {MenuLayout} defaultSubmenuLayout - The default MenuLayout
      * @returns {AddSubMenu} - The created AddSubMenu
      */
-    static subMenuCommandForMenuCell (cell, fileManager, windowCapability, position, defaultSubmenuLayout) {
-        const shouldCellIncludePrimaryImage = cell.getIcon() !== null && cell.getIcon().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludePrimaryImageFromCell(cell, fileManager, windowCapability);
+    static subMenuCommandForMenuCell (lifecycleManager, cell, fileManager, windowCapability, position, defaultSubmenuLayout) {
+        const shouldCellIncludePrimaryImage = cell.getIcon() !== null && cell.getIcon().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludePrimaryImageFromCell(lifecycleManager, cell, fileManager, windowCapability);
         const icon = shouldCellIncludePrimaryImage ? cell.getIcon().getImageRPC() : null;
-        const shouldCellIncludeSecondaryImage = cell.getSecondaryArtwork() !== null && cell.getSecondaryArtwork().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludeSecondaryImageFromCell(cell, fileManager, windowCapability);
+        const shouldCellIncludeSecondaryImage = cell.getSecondaryArtwork() !== null && cell.getSecondaryArtwork().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludeSecondaryImageFromCell(lifecycleManager, cell, fileManager, windowCapability);
         const secondaryIcon = shouldCellIncludeSecondaryImage ? cell.getSecondaryArtwork().getImageRPC() : null;
 
         let submenuLayout = null;

--- a/lib/js/src/manager/screen/menu/_MenuReplaceUtilities.js
+++ b/lib/js/src/manager/screen/menu/_MenuReplaceUtilities.js
@@ -157,19 +157,37 @@ class _MenuReplaceUtilities {
      * @returns {Boolean} - Whether the capability is supported
      */
     static windowCapabilitySupportsPrimaryImage (lifecycleManager = null, windowCapability, cell) {
+        let supportsImage;
         if (cell.isSubMenuCell() && lifecycleManager !== null && lifecycleManager.getSdlMsgVersion() !== null) {
-            const headUnitRpcVersion = new Version(lifecycleManager.getSdlMsgVersion());
-            const minRpcVersion = new Version(5, 0, 0);
-            const maxRpcVersion = new Version(7, 1, 0);
-            // If RPC version is >= 5.0 && < 7.1
-            if (headUnitRpcVersion.isNewerThan(minRpcVersion) === 0 || headUnitRpcVersion.isBetween(minRpcVersion, maxRpcVersion) === 1) {
-                return true;
+            if (_MenuReplaceUtilities.isRpcVersionBetween5And7(lifecycleManager) && _ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.cmdIcon)) {
+                supportsImage = true;
             } else {
-                return _ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.subMenuIcon);
+                supportsImage = _ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.subMenuIcon);
             }
         } else {
-            return _ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.cmdIcon);
+            supportsImage = _ManagerUtility.hasImageFieldOfName(windowCapability, ImageFieldName.cmdIcon);
         }
+        return supportsImage;
+    }
+
+    /**
+     * Checks whether the version is between 5.0.0 and 7.0.0
+     * @param {_LifecycleManager} lifecycleManager - A _LifecycleManager instance
+     * @returns {Boolean} - Whether the version is within bounds
+     */
+    static isRpcVersionBetween5And7 (lifecycleManager = null) {
+        if (lifecycleManager === null) {
+            return false;
+        }
+        const headUnitRpcVersion = new Version()
+            .setMajor(lifecycleManager.getSdlMsgVersion().getMajorVersion())
+            .setMinor(lifecycleManager.getSdlMsgVersion().getMinorVersion())
+            .setPatch(lifecycleManager.getSdlMsgVersion().getPatchVersion());
+
+        const minRpcVersion = new Version(5, 0, 0);
+        const maxRpcVersion = new Version(7, 0, 0);
+        // If RPC version is >= 5.0 && < 7.0
+        return (headUnitRpcVersion.isNewerThan(minRpcVersion) === 0 || headUnitRpcVersion.isBetween(minRpcVersion, maxRpcVersion) === 1);
     }
 
     /**

--- a/lib/js/src/manager/screen/menu/_MenuReplaceUtilities.js
+++ b/lib/js/src/manager/screen/menu/_MenuReplaceUtilities.js
@@ -215,13 +215,12 @@ class _MenuReplaceUtilities {
 
     /**
      * If there is an icon and the icon has been uploaded, or if the icon is a static icon, it should include the secondary image
-     * @param {_LifecycleManager} lifecycleManager - A _LifecycleManager instance
      * @param {MenuCell} cell - The menu cell to check
      * @param {FileManager} fileManager - Filemanager for checking artwork uploading
      * @param {WindowCapability} windowCapability - What the HMI is capable of
      * @returns {Boolean} - Whether a cell should include the secondary image
      */
-    static shouldCellIncludeSecondaryImageFromCell (lifecycleManager, cell, fileManager, windowCapability) {
+    static shouldCellIncludeSecondaryImageFromCell (cell, fileManager, windowCapability) {
         const supportsImage = _MenuReplaceUtilities.windowCapabilitySupportsSecondaryImage(windowCapability, cell);
         return cell.getSecondaryArtwork() !== null && supportsImage && (fileManager.hasUploadedFile(cell.getSecondaryArtwork()) || cell.getSecondaryArtwork().isStaticIcon());
     }
@@ -379,7 +378,7 @@ class _MenuReplaceUtilities {
         const shouldCellIncludePrimaryImage = cell.getIcon() !== null && cell.getIcon().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludePrimaryImageFromCell(lifecycleManager, cell, fileManager, windowCapability);
         command.setCmdIcon(shouldCellIncludePrimaryImage ? cell.getIcon().getImageRPC() : null);
 
-        const shouldCellIncludeSecondaryImage = cell.getSecondaryArtwork() !== null && cell.getSecondaryArtwork().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludeSecondaryImageFromCell(lifecycleManager, cell, fileManager, windowCapability);
+        const shouldCellIncludeSecondaryImage = cell.getSecondaryArtwork() !== null && cell.getSecondaryArtwork().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludeSecondaryImageFromCell(cell, fileManager, windowCapability);
         command.setSecondaryImage(shouldCellIncludeSecondaryImage ? cell.getSecondaryArtwork().getImageRPC() : null);
 
         return command;
@@ -398,7 +397,7 @@ class _MenuReplaceUtilities {
     static subMenuCommandForMenuCell (lifecycleManager, cell, fileManager, windowCapability, position, defaultSubmenuLayout) {
         const shouldCellIncludePrimaryImage = cell.getIcon() !== null && cell.getIcon().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludePrimaryImageFromCell(lifecycleManager, cell, fileManager, windowCapability);
         const icon = shouldCellIncludePrimaryImage ? cell.getIcon().getImageRPC() : null;
-        const shouldCellIncludeSecondaryImage = cell.getSecondaryArtwork() !== null && cell.getSecondaryArtwork().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludeSecondaryImageFromCell(lifecycleManager, cell, fileManager, windowCapability);
+        const shouldCellIncludeSecondaryImage = cell.getSecondaryArtwork() !== null && cell.getSecondaryArtwork().getImageRPC() !== null && _MenuReplaceUtilities.shouldCellIncludeSecondaryImageFromCell(cell, fileManager, windowCapability);
         const secondaryIcon = shouldCellIncludeSecondaryImage ? cell.getSecondaryArtwork().getImageRPC() : null;
 
         let submenuLayout = null;

--- a/tests/managers/screen/menu/MenuManagerTests.js
+++ b/tests/managers/screen/menu/MenuManagerTests.js
@@ -114,7 +114,7 @@ module.exports = function (appClient) {
             Validator.assertEquals(mm._dynamicMenuUpdatesMode, SDL.manager.screen.menu.enums.DynamicMenuUpdatesMode.FORCE_OFF);
             // when we only send one command to update, we should only be returned one add command
             const newArray = [mainCell1, mainCell4];
-            Validator.assertEquals(SDL.manager.screen.menu._MenuReplaceUtilities.allCommandsForCells(newArray, mm._fileManager, mm._windowCapability, SDL.rpc.enums.MenuLayout.LIST).length, 4);
+            Validator.assertEquals(SDL.manager.screen.menu._MenuReplaceUtilities.allCommandsForCells(sdlManager._lifecycleManager, newArray, mm._fileManager, mm._windowCapability, SDL.rpc.enums.MenuLayout.LIST).length, 4);
             mm._currentHmiLevel = SDL.rpc.enums.HMILevel.HMI_FULL;
             mm._setMenuCells(newArray);
 


### PR DESCRIPTION
Fixes #506 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Adds tests for the MenuReplaceUtilities class

### Summary
This PR makes two changes:
1. It will now add the AddSubmenu (menu cell w/ subcells) primary image on RPC connections >= 5.0 and < 7.0 because we don't have an image field name that corresponds to that image support.
2. It will now only upload menu cell images that are supported by the current window capability, which should be the same at all times.
