### PR TITLE
Check for null before attempting to call _supportsSoftButtonImages

### DIFF
--- a/lib/js/src/manager/screen/_SoftButtonReplaceOperation.js
+++ b/lib/js/src/manager/screen/_SoftButtonReplaceOperation.js
@@ -271,7 +271,7 @@ class _SoftButtonReplaceOperation extends _Task {
      * @returns {Boolean} - Whether soft button images are supported
      */
     _supportsSoftButtonImages () {
-        return this._softButtonCapabilities.getImageSupported();
+        return this._softButtonCapabilities && this._softButtonCapabilities.getImageSupported();
     }
 
     /**

--- a/lib/js/src/manager/screen/_SoftButtonReplaceOperation.js
+++ b/lib/js/src/manager/screen/_SoftButtonReplaceOperation.js
@@ -271,7 +271,7 @@ class _SoftButtonReplaceOperation extends _Task {
      * @returns {Boolean} - Whether soft button images are supported
      */
     _supportsSoftButtonImages () {
-        return this._softButtonCapabilities && this._softButtonCapabilities.getImageSupported();
+        return this._softButtonCapabilities !== null && this._softButtonCapabilities.getImageSupported();
     }
 
     /**


### PR DESCRIPTION
Fixes #515 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Checks if soft button capabilities in the softbuttonreplaceoperation class is null first before calling its method.