### PR TITLE
Handle language and hmi display language separately on registration

### DIFF
--- a/examples/js/hello-sdl/index.html
+++ b/examples/js/hello-sdl/index.html
@@ -94,6 +94,11 @@
                     })
                     .setOnError((sdlManager, info) => {
                         console.error('Error from SdlManagerListener: ', info);
+                    })
+                    .setManagerShouldUpdateLifecycleToLanguage((language = null, hmiLanguage = null) => {
+                        return new SDL.manager.lifecycle.LifecycleConfigurationUpdate()
+                                .setAppName('Hello JS')
+                                .setTtsName([new SDL.rpc.structs.TTSChunk().setText('Hello JS')]);
                     });
 
                 this._sdlManager = new SDL.manager.SdlManager(this._appConfig, managerListener);

--- a/examples/node/hello-sdl-tcp/index.js
+++ b/examples/node/hello-sdl-tcp/index.js
@@ -47,6 +47,7 @@ class AppClient {
             .setAppId(CONFIG.appId)
             .setAppName(CONFIG.appName)
             .setLanguageDesired(SDL.rpc.enums.Language.EN_US)
+            .setHmiDisplayLanguageDesired(SDL.rpc.enums.Language.EN_US)
             .setAppTypes([
                 SDL.rpc.enums.AppHMIType.MEDIA,
             ])
@@ -89,6 +90,11 @@ class AppClient {
             })
             .setOnError((sdlManager, info) => {
                 console.error('Error from SdlManagerListener: ', info);
+            })
+            .setManagerShouldUpdateLifecycleToLanguage((language = null, hmiLanguage = null) => {
+                return new SDL.manager.lifecycle.LifecycleConfigurationUpdate()
+                    .setAppName('Hello JS')
+                    .setTtsName([new SDL.rpc.structs.TTSChunk().setText('Hello JS')]);
             });
 
         this._sdlManager = new SDL.manager.SdlManager(this._appConfig, managerListener);

--- a/examples/node/hello-sdl/AppClient.js
+++ b/examples/node/hello-sdl/AppClient.js
@@ -47,6 +47,7 @@ class AppClient {
             .setAppId(CONFIG.appId)
             .setAppName(CONFIG.appName)
             .setLanguageDesired(SDL.rpc.enums.Language.EN_US)
+            .setHmiDisplayLanguageDesired(SDL.rpc.enums.Language.EN_US)
             .setAppTypes([
                 SDL.rpc.enums.AppHMIType.MEDIA,
             ])
@@ -94,6 +95,11 @@ class AppClient {
             })
             .setOnError((sdlManager, info) => {
                 console.error('Error from SdlManagerListener: ', info);
+            })
+            .setManagerShouldUpdateLifecycleToLanguage((language = null, hmiLanguage = null) => {
+                return new SDL.manager.lifecycle.LifecycleConfigurationUpdate()
+                    .setAppName('Hello JS')
+                    .setTtsName([new SDL.rpc.structs.TTSChunk().setText('Hello JS')]);
             });
 
         this._sdlManager = new SDL.manager.SdlManager(this._appConfig, managerListener);

--- a/examples/webengine/hello-sdl/index.html
+++ b/examples/webengine/hello-sdl/index.html
@@ -86,6 +86,11 @@
                     })
                     .setOnError((sdlManager, info) => {
                         this._logMessage('APP:', 'Error from SdlManagerListener: ' + info, true);
+                    })
+                    .setManagerShouldUpdateLifecycleToLanguage((language = null, hmiLanguage = null) => {
+                        return new SDL.manager.lifecycle.LifecycleConfigurationUpdate()
+                            .setAppName('Hello JS')
+                            .setTtsName([new SDL.rpc.structs.TTSChunk().setText('Hello JS')]);
                     });
 
                 this._sdlManager = new SDL.manager.SdlManager(this._appConfig, managerListener);

--- a/lib/js/src/manager/SdlManager.js
+++ b/lib/js/src/manager/SdlManager.js
@@ -222,18 +222,29 @@ class SdlManager extends _SdlManagerBase {
      */
     _checkLifecycleConfiguration () {
         const actualLanguage = this._lifecycleManager.getRegisterAppInterfaceResponse().getLanguage();
+        const actualHmiLanguage = this._lifecycleManager.getRegisterAppInterfaceResponse().getHmiDisplayLanguage();
 
-        if (actualLanguage !== null && actualLanguage !== this._lifecycleConfig.getLanguageDesired()) {
+        if ((actualLanguage !== null && actualLanguage !== this._lifecycleConfig.getLanguageDesired())
+            || (actualHmiLanguage !== null && actualHmiLanguage !== this._lifecycleConfig.getHmiDisplayLanguageDesired())) {
             // HMI language doesn't match the app's desired display language
-            const lifecycleConfigUpdate = this._managerListener.managerShouldUpdateLifecycle(actualLanguage);
+            const lifecycleConfigUpdateNew = this._managerListener.managerShouldUpdateLifecycleToLanguage(actualLanguage, actualHmiLanguage);
+            const lifecycleConfigUpdateOld = this._managerListener.managerShouldUpdateLifecycle(actualLanguage);
+            let lifecycleConfigUpdate;
+            const changeRegistration = new ChangeRegistration();
+
+            if (lifecycleConfigUpdateNew === null) {
+                lifecycleConfigUpdate = lifecycleConfigUpdateOld;
+                changeRegistration.setLanguage(actualLanguage)
+                    .setHmiDisplayLanguage(actualLanguage);
+            } else {
+                lifecycleConfigUpdate = lifecycleConfigUpdateNew;
+                changeRegistration.setLanguage(actualLanguage)
+                    .setHmiDisplayLanguage(actualHmiLanguage);
+            }
 
             if (lifecycleConfigUpdate !== null) {
                 // send a ChangeRegistration RPC
-                const changeRegistration = new ChangeRegistration();
-                changeRegistration
-                    .setLanguage(actualLanguage)
-                    .setHmiDisplayLanguage(actualLanguage)
-                    .setAppName(lifecycleConfigUpdate.getAppName())
+                changeRegistration.setAppName(lifecycleConfigUpdate.getAppName())
                     .setNgnMediaScreenAppName(lifecycleConfigUpdate.getShortAppName())
                     .setVrSynonyms(lifecycleConfigUpdate.getVoiceRecognitionCommandNames());
 
@@ -244,7 +255,7 @@ class SdlManager extends _SdlManagerBase {
                 this.sendRpcResolve(changeRegistration)
                     .then((response) => {
                         this._lifecycleConfig.setLanguageDesired(actualLanguage);
-                        this._lifecycleConfig.setHmiDisplayLanguageDesired(actualLanguage);
+                        this._lifecycleConfig.setHmiDisplayLanguageDesired(actualHmiLanguage);
                         if (lifecycleConfigUpdate.getAppName() !== null) {
                             this._lifecycleConfig.setAppName(lifecycleConfigUpdate.getAppName());
                         }

--- a/lib/js/src/manager/SdlManagerListener.js
+++ b/lib/js/src/manager/SdlManagerListener.js
@@ -42,6 +42,9 @@ class SdlManagerListener {
         this._managerShouldUpdateLifecycle = (language) => {
             return null;
         };
+        this._managerShouldUpdateLifecycleToLanguage = (language, hmiLanguage) => {
+            return null;
+        };
         this._onSystemInfoReceived = null;
     }
 
@@ -77,11 +80,22 @@ class SdlManagerListener {
 
     /**
      * Set the ManagerShouldUpdateLifecycle event callback function.
+     * @deprecated Use setManagerShouldUpdateLifecycleToLanguage instead
      * @param {function} callback - A function to invoke when the event is triggered.
      * @returns {SdlManagerListener} - A reference to this instance to support method chaining.
      */
     setManagerShouldUpdateLifecycle (callback) {
         this._managerShouldUpdateLifecycle = callback;
+        return this;
+    }
+
+    /**
+     * Set the ManagerShouldUpdateLifecycleToLanguage event callback function.
+     * @param {function} callback - A function to invoke when the event is triggered.
+     * @returns {SdlManagerListener} - A reference to this instance to support method chaining.
+     */
+    setManagerShouldUpdateLifecycleToLanguage (callback) {
+        this._managerShouldUpdateLifecycleToLanguage = callback;
         return this;
     }
 
@@ -118,12 +132,30 @@ class SdlManagerListener {
 
     /**
      * Safely attempts to invoke the ManagerShouldUpdateLifecycle event callback function.
+     * @deprecated Use managerShouldUpdateLifecycleToLanguage instead
      * @param {Language} language - A Language enum value.
      * @returns {LifecycleConfigurationUpdate|null} - A reference to LifecycleConfigurationUpdate instance or null
      */
     managerShouldUpdateLifecycle (language) {
         if (typeof this._managerShouldUpdateLifecycle === 'function') {
             return this._managerShouldUpdateLifecycle(language);
+        }
+        return null;
+    }
+
+    /**
+     * Called when the SDL manager detected a language mismatch. In case of a language mismatch the
+     * manager should change the apps registration by updating the lifecycle configuration to the
+     * specified language. If the app can support the specified language it should return an Object
+     * of LifecycleConfigurationUpdate, otherwise it should return null to indicate that the language
+     * is not supported.
+     * @param {Language} language - The VR+TTS language of the connected head unit the manager is trying to update the configuration.
+     * @param {Language} hmiLanguage - The HMI display language of the connected head unit the manager is trying to update the configuration.
+     * @returns {LifecycleConfigurationUpdate|null} - A reference to LifecycleConfigurationUpdate instance or null
+     */
+    managerShouldUpdateLifecycleToLanguage (language, hmiLanguage) {
+        if (typeof this._managerShouldUpdateLifecycleToLanguage === 'function') {
+            return this._managerShouldUpdateLifecycleToLanguage(language, hmiLanguage);
         }
         return null;
     }

--- a/lib/js/src/manager/lifecycle/_LifecycleManager.js
+++ b/lib/js/src/manager/lifecycle/_LifecycleManager.js
@@ -412,7 +412,7 @@ class _LifecycleManager {
             .setNgnMediaScreenAppName(this._lifecycleConfig.getShortAppName())
             .setAppHMIType(this._lifecycleConfig.getAppTypes())
             .setLanguageDesired(this._lifecycleConfig.getLanguageDesired())
-            .setHmiDisplayLanguageDesired(this._lifecycleConfig.getLanguageDesired())
+            .setHmiDisplayLanguageDesired(this._lifecycleConfig.getHmiDisplayLanguageDesired())
             .setIsMediaApplication(this._lifecycleConfig._isMediaApp)
             .setDayColorScheme(this._lifecycleConfig.getDayColorScheme())
             .setNightColorScheme(this._lifecycleConfig.getNightColorScheme())

--- a/tests/managers/SdlManagerTests.js
+++ b/tests/managers/SdlManagerTests.js
@@ -1,0 +1,74 @@
+const expect = require('chai').expect;
+const SDL = require('../config.js').node;
+
+// Mocking framework used so that some RPCs are not actually sent to Core, but the response mimicked
+const sinon = require('sinon');
+
+const Validator = require('../Validator');
+
+module.exports = function (appClient) {
+    describe('SdlManagerTests', function () {
+        let originalHmiLanguage;
+        const sdlManager = appClient._sdlManager;
+        before(() => {
+            originalHmiLanguage = sdlManager._lifecycleManager.getRegisterAppInterfaceResponse().getHmiDisplayLanguage();
+        });
+        beforeEach(() => {
+            const language = sdlManager._lifecycleManager.getRegisterAppInterfaceResponse().getHmiDisplayLanguage();
+            // create a mismatch that can be checked for in testing
+            switch (language) {
+                case SDL.rpc.enums.Language.EN_US:
+                    sdlManager._lifecycleManager.getRegisterAppInterfaceResponse().setHmiDisplayLanguage(SDL.rpc.enums.Language.ES_MX);
+                    sdlManager._lifecycleConfig.setHmiDisplayLanguageDesired(SDL.rpc.enums.Language.EN_US);
+                    break;
+                default:
+                    sdlManager._lifecycleManager.getRegisterAppInterfaceResponse().setHmiDisplayLanguage(SDL.rpc.enums.Language.EN_US);
+                    sdlManager._lifecycleConfig.setHmiDisplayLanguageDesired(SDL.rpc.enums.Language.ES_MX);
+                    break;
+            }
+        });
+        it('managerShouldUpdateLifecycleToLanguage', function (done) {
+            const stub = sinon.stub(sdlManager._lifecycleManager, 'sendRpcResolve')
+                .callsFake((changeRegistration) => {
+                    Validator.assertEquals(changeRegistration.getAppName(), 'Hello JS');
+                    Validator.assertEquals(changeRegistration.getTtsName(), [new SDL.rpc.structs.TTSChunk().setText('Hello JS')]);
+
+                    expect(changeRegistration.getLanguage()).to.equal(SDL.rpc.enums.Language.EN_US);
+                    expect(changeRegistration.getHmiDisplayLanguage()).to.equal(SDL.rpc.enums.Language.ES_MX);
+
+                    stub.restore();
+                    done();
+                });
+            sdlManager._managerListener.setManagerShouldUpdateLifecycleToLanguage((language = null, hmiLanguage = null) => {
+                return new SDL.manager.lifecycle.LifecycleConfigurationUpdate()
+                    .setAppName('Hello JS')
+                    .setTtsName([new SDL.rpc.structs.TTSChunk().setText('Hello JS')]);
+            });
+            sdlManager._checkLifecycleConfiguration();
+        });
+        it('managerShouldUpdateLifecycle', function (done) {
+            const stub = sinon.stub(sdlManager._lifecycleManager, 'sendRpcResolve')
+                .callsFake((changeRegistration) => {
+                    Validator.assertEquals(changeRegistration.getAppName(), 'Hello JS');
+                    Validator.assertEquals(changeRegistration.getTtsName(), [new SDL.rpc.structs.TTSChunk().setText('Hello JS')]);
+                    // These languages should be the same because hmiDisplayLanguage was not used in older versions
+                    expect(changeRegistration.getLanguage()).to.equal(changeRegistration.getHmiDisplayLanguage());
+                    // Confirm that the desired languages are not actually the same
+                    expect(sdlManager._lifecycleConfig.getLanguageDesired()).to.equal(SDL.rpc.enums.Language.EN_US);
+                    expect(sdlManager._lifecycleConfig.getHmiDisplayLanguageDesired()).to.equal(SDL.rpc.enums.Language.ES_MX);
+
+                    stub.restore();
+                    done();
+                });
+            sdlManager._managerListener.setManagerShouldUpdateLifecycle((language = null) => {
+                return new SDL.manager.lifecycle.LifecycleConfigurationUpdate()
+                    .setAppName('Hello JS')
+                    .setTtsName([new SDL.rpc.structs.TTSChunk().setText('Hello JS')]);
+            });
+            sdlManager._checkLifecycleConfiguration();
+        });
+        after(() => {
+            sdlManager._lifecycleManager.getRegisterAppInterfaceResponse().setHmiDisplayLanguage(originalHmiLanguage);
+        });
+    });
+};

--- a/tests/managers/index.js
+++ b/tests/managers/index.js
@@ -33,6 +33,7 @@ const choiceSetManagerTests = require('./screen/choiceset/ChoiceSetManagerTests'
 const choiceSetTests = require('./screen/choiceset/ChoiceSetTests');
 const preloadPresentChoicesOperationTests = require('./screen/choiceset/PreloadPresentChoicesOperationTests');
 const presentKeyboardOperationTests = require('./screen/choiceset/PresentKeyboardOperationTests');
+const sdlManagerTests = require('./SdlManagerTests');
 
 // connect to core and select the app on the HMI to run the tests
 describe('ManagerTests', function () {
@@ -76,6 +77,7 @@ describe('ManagerTests', function () {
                 fileManagerTests(appClient);
                 uploadFileOperationTests(appClient);
                 sdlFileTests(appClient);
+                sdlManagerTests(appClient);
 
                 setTimeout(function () {
                     // teardown();


### PR DESCRIPTION
Fixes #131 

### Risk
This PR makes **minor** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
This PR updates the SdlManager to use the correct hmiDisplayLanguageDesired field of the LifecycleConfig when attempting to change the registration of an app in the event of a mismatch between the HMI's supported languages and an app's desired languages.

#### Unit Tests
Unit tests have been added to confirm that the languageDesired and hmiDisplayLanguageDesired are set independently upon a language mismatch.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
