### PR TITLE
Update RPC file copyright years to 2022

### DIFF
--- a/lib/js/src/rpc/RpcCreator.js
+++ b/lib/js/src/rpc/RpcCreator.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/AmbientLightStatus.js
+++ b/lib/js/src/rpc/enums/AmbientLightStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/AppCapabilityType.js
+++ b/lib/js/src/rpc/enums/AppCapabilityType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/AppHMIType.js
+++ b/lib/js/src/rpc/enums/AppHMIType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/AppInterfaceUnregisteredReason.js
+++ b/lib/js/src/rpc/enums/AppInterfaceUnregisteredReason.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/AppServiceType.js
+++ b/lib/js/src/rpc/enums/AppServiceType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/AudioStreamingIndicator.js
+++ b/lib/js/src/rpc/enums/AudioStreamingIndicator.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/AudioStreamingState.js
+++ b/lib/js/src/rpc/enums/AudioStreamingState.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/AudioType.js
+++ b/lib/js/src/rpc/enums/AudioType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/BitsPerSample.js
+++ b/lib/js/src/rpc/enums/BitsPerSample.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/ButtonEventMode.js
+++ b/lib/js/src/rpc/enums/ButtonEventMode.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/ButtonName.js
+++ b/lib/js/src/rpc/enums/ButtonName.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/ButtonPressMode.js
+++ b/lib/js/src/rpc/enums/ButtonPressMode.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/CapacityUnit.js
+++ b/lib/js/src/rpc/enums/CapacityUnit.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/CarModeStatus.js
+++ b/lib/js/src/rpc/enums/CarModeStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/CharacterSet.js
+++ b/lib/js/src/rpc/enums/CharacterSet.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/CompassDirection.js
+++ b/lib/js/src/rpc/enums/CompassDirection.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/ComponentVolumeStatus.js
+++ b/lib/js/src/rpc/enums/ComponentVolumeStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/DefrostZone.js
+++ b/lib/js/src/rpc/enums/DefrostZone.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/DeliveryMode.js
+++ b/lib/js/src/rpc/enums/DeliveryMode.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/DeviceLevelStatus.js
+++ b/lib/js/src/rpc/enums/DeviceLevelStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/Dimension.js
+++ b/lib/js/src/rpc/enums/Dimension.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/Direction.js
+++ b/lib/js/src/rpc/enums/Direction.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/DisplayMode.js
+++ b/lib/js/src/rpc/enums/DisplayMode.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/DisplayType.js
+++ b/lib/js/src/rpc/enums/DisplayType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/DistanceUnit.js
+++ b/lib/js/src/rpc/enums/DistanceUnit.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/DoorStatusType.js
+++ b/lib/js/src/rpc/enums/DoorStatusType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/DriverDistractionState.js
+++ b/lib/js/src/rpc/enums/DriverDistractionState.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/ECallConfirmationStatus.js
+++ b/lib/js/src/rpc/enums/ECallConfirmationStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/ElectronicParkBrakeStatus.js
+++ b/lib/js/src/rpc/enums/ElectronicParkBrakeStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/EmergencyEventType.js
+++ b/lib/js/src/rpc/enums/EmergencyEventType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/FileType.js
+++ b/lib/js/src/rpc/enums/FileType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/FuelCutoffStatus.js
+++ b/lib/js/src/rpc/enums/FuelCutoffStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/FuelType.js
+++ b/lib/js/src/rpc/enums/FuelType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/FunctionID.js
+++ b/lib/js/src/rpc/enums/FunctionID.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/GlobalProperty.js
+++ b/lib/js/src/rpc/enums/GlobalProperty.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/HMILevel.js
+++ b/lib/js/src/rpc/enums/HMILevel.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/HmiZoneCapabilities.js
+++ b/lib/js/src/rpc/enums/HmiZoneCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/HybridAppPreference.js
+++ b/lib/js/src/rpc/enums/HybridAppPreference.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/IgnitionStableStatus.js
+++ b/lib/js/src/rpc/enums/IgnitionStableStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/IgnitionStatus.js
+++ b/lib/js/src/rpc/enums/IgnitionStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/ImageFieldName.js
+++ b/lib/js/src/rpc/enums/ImageFieldName.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/ImageType.js
+++ b/lib/js/src/rpc/enums/ImageType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/InteractionMode.js
+++ b/lib/js/src/rpc/enums/InteractionMode.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/KeyboardEvent.js
+++ b/lib/js/src/rpc/enums/KeyboardEvent.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/KeyboardInputMask.js
+++ b/lib/js/src/rpc/enums/KeyboardInputMask.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/KeyboardLayout.js
+++ b/lib/js/src/rpc/enums/KeyboardLayout.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/KeypressMode.js
+++ b/lib/js/src/rpc/enums/KeypressMode.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/Language.js
+++ b/lib/js/src/rpc/enums/Language.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/LayoutMode.js
+++ b/lib/js/src/rpc/enums/LayoutMode.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/LightName.js
+++ b/lib/js/src/rpc/enums/LightName.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/LightStatus.js
+++ b/lib/js/src/rpc/enums/LightStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/MaintenanceModeStatus.js
+++ b/lib/js/src/rpc/enums/MaintenanceModeStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/MassageCushion.js
+++ b/lib/js/src/rpc/enums/MassageCushion.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/MassageMode.js
+++ b/lib/js/src/rpc/enums/MassageMode.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/MassageZone.js
+++ b/lib/js/src/rpc/enums/MassageZone.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/MediaClockFormat.js
+++ b/lib/js/src/rpc/enums/MediaClockFormat.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/MediaType.js
+++ b/lib/js/src/rpc/enums/MediaType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/MenuLayout.js
+++ b/lib/js/src/rpc/enums/MenuLayout.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/MessageType.js
+++ b/lib/js/src/rpc/enums/MessageType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/MetadataType.js
+++ b/lib/js/src/rpc/enums/MetadataType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/ModuleType.js
+++ b/lib/js/src/rpc/enums/ModuleType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/NavigationAction.js
+++ b/lib/js/src/rpc/enums/NavigationAction.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/NavigationJunction.js
+++ b/lib/js/src/rpc/enums/NavigationJunction.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/PRNDL.js
+++ b/lib/js/src/rpc/enums/PRNDL.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/PermissionStatus.js
+++ b/lib/js/src/rpc/enums/PermissionStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/PowerModeQualificationStatus.js
+++ b/lib/js/src/rpc/enums/PowerModeQualificationStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/PowerModeStatus.js
+++ b/lib/js/src/rpc/enums/PowerModeStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/PredefinedLayout.js
+++ b/lib/js/src/rpc/enums/PredefinedLayout.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/PredefinedWindows.js
+++ b/lib/js/src/rpc/enums/PredefinedWindows.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/PrerecordedSpeech.js
+++ b/lib/js/src/rpc/enums/PrerecordedSpeech.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/PrimaryAudioSource.js
+++ b/lib/js/src/rpc/enums/PrimaryAudioSource.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/RadioBand.js
+++ b/lib/js/src/rpc/enums/RadioBand.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/RadioState.js
+++ b/lib/js/src/rpc/enums/RadioState.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/RequestType.js
+++ b/lib/js/src/rpc/enums/RequestType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/Result.js
+++ b/lib/js/src/rpc/enums/Result.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/SamplingRate.js
+++ b/lib/js/src/rpc/enums/SamplingRate.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/SeatMemoryActionType.js
+++ b/lib/js/src/rpc/enums/SeatMemoryActionType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/SeekIndicatorType.js
+++ b/lib/js/src/rpc/enums/SeekIndicatorType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/ServiceUpdateReason.js
+++ b/lib/js/src/rpc/enums/ServiceUpdateReason.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/SoftButtonType.js
+++ b/lib/js/src/rpc/enums/SoftButtonType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/SpeechCapabilities.js
+++ b/lib/js/src/rpc/enums/SpeechCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/SupportedSeat.js
+++ b/lib/js/src/rpc/enums/SupportedSeat.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/SystemAction.js
+++ b/lib/js/src/rpc/enums/SystemAction.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/SystemCapabilityType.js
+++ b/lib/js/src/rpc/enums/SystemCapabilityType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/SystemContext.js
+++ b/lib/js/src/rpc/enums/SystemContext.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/TBTState.js
+++ b/lib/js/src/rpc/enums/TBTState.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/TPMS.js
+++ b/lib/js/src/rpc/enums/TPMS.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/TemperatureUnit.js
+++ b/lib/js/src/rpc/enums/TemperatureUnit.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/TextAlignment.js
+++ b/lib/js/src/rpc/enums/TextAlignment.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/TextFieldName.js
+++ b/lib/js/src/rpc/enums/TextFieldName.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/TimerMode.js
+++ b/lib/js/src/rpc/enums/TimerMode.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/TouchType.js
+++ b/lib/js/src/rpc/enums/TouchType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/TransmissionType.js
+++ b/lib/js/src/rpc/enums/TransmissionType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/TriggerSource.js
+++ b/lib/js/src/rpc/enums/TriggerSource.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/TurnSignal.js
+++ b/lib/js/src/rpc/enums/TurnSignal.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/UpdateMode.js
+++ b/lib/js/src/rpc/enums/UpdateMode.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/VehicleDataActiveStatus.js
+++ b/lib/js/src/rpc/enums/VehicleDataActiveStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/VehicleDataEventStatus.js
+++ b/lib/js/src/rpc/enums/VehicleDataEventStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/VehicleDataNotificationStatus.js
+++ b/lib/js/src/rpc/enums/VehicleDataNotificationStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/VehicleDataResultCode.js
+++ b/lib/js/src/rpc/enums/VehicleDataResultCode.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/VehicleDataStatus.js
+++ b/lib/js/src/rpc/enums/VehicleDataStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/VehicleDataType.js
+++ b/lib/js/src/rpc/enums/VehicleDataType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/VentilationMode.js
+++ b/lib/js/src/rpc/enums/VentilationMode.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/VideoStreamingCodec.js
+++ b/lib/js/src/rpc/enums/VideoStreamingCodec.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/VideoStreamingProtocol.js
+++ b/lib/js/src/rpc/enums/VideoStreamingProtocol.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/VideoStreamingState.js
+++ b/lib/js/src/rpc/enums/VideoStreamingState.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/VrCapabilities.js
+++ b/lib/js/src/rpc/enums/VrCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/WarningLightStatus.js
+++ b/lib/js/src/rpc/enums/WarningLightStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/WayPointType.js
+++ b/lib/js/src/rpc/enums/WayPointType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/WindowType.js
+++ b/lib/js/src/rpc/enums/WindowType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/enums/WiperStatus.js
+++ b/lib/js/src/rpc/enums/WiperStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/AddCommand.js
+++ b/lib/js/src/rpc/messages/AddCommand.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/AddCommandResponse.js
+++ b/lib/js/src/rpc/messages/AddCommandResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/AddSubMenu.js
+++ b/lib/js/src/rpc/messages/AddSubMenu.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/AddSubMenuResponse.js
+++ b/lib/js/src/rpc/messages/AddSubMenuResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/Alert.js
+++ b/lib/js/src/rpc/messages/Alert.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/AlertManeuver.js
+++ b/lib/js/src/rpc/messages/AlertManeuver.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/AlertManeuverResponse.js
+++ b/lib/js/src/rpc/messages/AlertManeuverResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/AlertResponse.js
+++ b/lib/js/src/rpc/messages/AlertResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ButtonPress.js
+++ b/lib/js/src/rpc/messages/ButtonPress.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ButtonPressResponse.js
+++ b/lib/js/src/rpc/messages/ButtonPressResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/CancelInteraction.js
+++ b/lib/js/src/rpc/messages/CancelInteraction.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/CancelInteractionResponse.js
+++ b/lib/js/src/rpc/messages/CancelInteractionResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ChangeRegistration.js
+++ b/lib/js/src/rpc/messages/ChangeRegistration.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ChangeRegistrationResponse.js
+++ b/lib/js/src/rpc/messages/ChangeRegistrationResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/CloseApplication.js
+++ b/lib/js/src/rpc/messages/CloseApplication.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/CloseApplicationResponse.js
+++ b/lib/js/src/rpc/messages/CloseApplicationResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/CreateInteractionChoiceSet.js
+++ b/lib/js/src/rpc/messages/CreateInteractionChoiceSet.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/CreateInteractionChoiceSetResponse.js
+++ b/lib/js/src/rpc/messages/CreateInteractionChoiceSetResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/CreateWindow.js
+++ b/lib/js/src/rpc/messages/CreateWindow.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/CreateWindowResponse.js
+++ b/lib/js/src/rpc/messages/CreateWindowResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/DeleteCommand.js
+++ b/lib/js/src/rpc/messages/DeleteCommand.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/DeleteCommandResponse.js
+++ b/lib/js/src/rpc/messages/DeleteCommandResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/DeleteFile.js
+++ b/lib/js/src/rpc/messages/DeleteFile.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/DeleteFileResponse.js
+++ b/lib/js/src/rpc/messages/DeleteFileResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/DeleteInteractionChoiceSet.js
+++ b/lib/js/src/rpc/messages/DeleteInteractionChoiceSet.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/DeleteInteractionChoiceSetResponse.js
+++ b/lib/js/src/rpc/messages/DeleteInteractionChoiceSetResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/DeleteSubMenu.js
+++ b/lib/js/src/rpc/messages/DeleteSubMenu.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/DeleteSubMenuResponse.js
+++ b/lib/js/src/rpc/messages/DeleteSubMenuResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/DeleteWindow.js
+++ b/lib/js/src/rpc/messages/DeleteWindow.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/DeleteWindowResponse.js
+++ b/lib/js/src/rpc/messages/DeleteWindowResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/DiagnosticMessage.js
+++ b/lib/js/src/rpc/messages/DiagnosticMessage.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/DiagnosticMessageResponse.js
+++ b/lib/js/src/rpc/messages/DiagnosticMessageResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/DialNumber.js
+++ b/lib/js/src/rpc/messages/DialNumber.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/DialNumberResponse.js
+++ b/lib/js/src/rpc/messages/DialNumberResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/EncodedSyncPData.js
+++ b/lib/js/src/rpc/messages/EncodedSyncPData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/EncodedSyncPDataResponse.js
+++ b/lib/js/src/rpc/messages/EncodedSyncPDataResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/EndAudioPassThru.js
+++ b/lib/js/src/rpc/messages/EndAudioPassThru.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/EndAudioPassThruResponse.js
+++ b/lib/js/src/rpc/messages/EndAudioPassThruResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GenericResponseResponse.js
+++ b/lib/js/src/rpc/messages/GenericResponseResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetAppServiceData.js
+++ b/lib/js/src/rpc/messages/GetAppServiceData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetAppServiceDataResponse.js
+++ b/lib/js/src/rpc/messages/GetAppServiceDataResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetCloudAppProperties.js
+++ b/lib/js/src/rpc/messages/GetCloudAppProperties.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetCloudAppPropertiesResponse.js
+++ b/lib/js/src/rpc/messages/GetCloudAppPropertiesResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetDTCs.js
+++ b/lib/js/src/rpc/messages/GetDTCs.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetDTCsResponse.js
+++ b/lib/js/src/rpc/messages/GetDTCsResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetFile.js
+++ b/lib/js/src/rpc/messages/GetFile.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetFileResponse.js
+++ b/lib/js/src/rpc/messages/GetFileResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetInteriorVehicleData.js
+++ b/lib/js/src/rpc/messages/GetInteriorVehicleData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetInteriorVehicleDataConsent.js
+++ b/lib/js/src/rpc/messages/GetInteriorVehicleDataConsent.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetInteriorVehicleDataConsentResponse.js
+++ b/lib/js/src/rpc/messages/GetInteriorVehicleDataConsentResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetInteriorVehicleDataResponse.js
+++ b/lib/js/src/rpc/messages/GetInteriorVehicleDataResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetSystemCapability.js
+++ b/lib/js/src/rpc/messages/GetSystemCapability.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetSystemCapabilityResponse.js
+++ b/lib/js/src/rpc/messages/GetSystemCapabilityResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetVehicleData.js
+++ b/lib/js/src/rpc/messages/GetVehicleData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetVehicleDataResponse.js
+++ b/lib/js/src/rpc/messages/GetVehicleDataResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetWayPoints.js
+++ b/lib/js/src/rpc/messages/GetWayPoints.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/GetWayPointsResponse.js
+++ b/lib/js/src/rpc/messages/GetWayPointsResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ListFiles.js
+++ b/lib/js/src/rpc/messages/ListFiles.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ListFilesResponse.js
+++ b/lib/js/src/rpc/messages/ListFilesResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnAppCapabilityUpdated.js
+++ b/lib/js/src/rpc/messages/OnAppCapabilityUpdated.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnAppInterfaceUnregistered.js
+++ b/lib/js/src/rpc/messages/OnAppInterfaceUnregistered.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnAppServiceData.js
+++ b/lib/js/src/rpc/messages/OnAppServiceData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnAudioPassThru.js
+++ b/lib/js/src/rpc/messages/OnAudioPassThru.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnButtonEvent.js
+++ b/lib/js/src/rpc/messages/OnButtonEvent.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnButtonPress.js
+++ b/lib/js/src/rpc/messages/OnButtonPress.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnCommand.js
+++ b/lib/js/src/rpc/messages/OnCommand.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnDriverDistraction.js
+++ b/lib/js/src/rpc/messages/OnDriverDistraction.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnEncodedSyncPData.js
+++ b/lib/js/src/rpc/messages/OnEncodedSyncPData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnHMIStatus.js
+++ b/lib/js/src/rpc/messages/OnHMIStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnHashChange.js
+++ b/lib/js/src/rpc/messages/OnHashChange.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnInteriorVehicleData.js
+++ b/lib/js/src/rpc/messages/OnInteriorVehicleData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnKeyboardInput.js
+++ b/lib/js/src/rpc/messages/OnKeyboardInput.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnLanguageChange.js
+++ b/lib/js/src/rpc/messages/OnLanguageChange.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnPermissionsChange.js
+++ b/lib/js/src/rpc/messages/OnPermissionsChange.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnRCStatus.js
+++ b/lib/js/src/rpc/messages/OnRCStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnSubtleAlertPressed.js
+++ b/lib/js/src/rpc/messages/OnSubtleAlertPressed.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnSystemCapabilityUpdated.js
+++ b/lib/js/src/rpc/messages/OnSystemCapabilityUpdated.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnSystemRequest.js
+++ b/lib/js/src/rpc/messages/OnSystemRequest.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnTBTClientState.js
+++ b/lib/js/src/rpc/messages/OnTBTClientState.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnTouchEvent.js
+++ b/lib/js/src/rpc/messages/OnTouchEvent.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnUpdateFile.js
+++ b/lib/js/src/rpc/messages/OnUpdateFile.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnUpdateSubMenu.js
+++ b/lib/js/src/rpc/messages/OnUpdateSubMenu.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnVehicleData.js
+++ b/lib/js/src/rpc/messages/OnVehicleData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/OnWayPointChange.js
+++ b/lib/js/src/rpc/messages/OnWayPointChange.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/PerformAppServiceInteraction.js
+++ b/lib/js/src/rpc/messages/PerformAppServiceInteraction.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/PerformAppServiceInteractionResponse.js
+++ b/lib/js/src/rpc/messages/PerformAppServiceInteractionResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/PerformAudioPassThru.js
+++ b/lib/js/src/rpc/messages/PerformAudioPassThru.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/PerformAudioPassThruResponse.js
+++ b/lib/js/src/rpc/messages/PerformAudioPassThruResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/PerformInteraction.js
+++ b/lib/js/src/rpc/messages/PerformInteraction.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/PerformInteractionResponse.js
+++ b/lib/js/src/rpc/messages/PerformInteractionResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/PublishAppService.js
+++ b/lib/js/src/rpc/messages/PublishAppService.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/PublishAppServiceResponse.js
+++ b/lib/js/src/rpc/messages/PublishAppServiceResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/PutFile.js
+++ b/lib/js/src/rpc/messages/PutFile.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/PutFileResponse.js
+++ b/lib/js/src/rpc/messages/PutFileResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ReadDID.js
+++ b/lib/js/src/rpc/messages/ReadDID.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ReadDIDResponse.js
+++ b/lib/js/src/rpc/messages/ReadDIDResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/RegisterAppInterface.js
+++ b/lib/js/src/rpc/messages/RegisterAppInterface.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/RegisterAppInterfaceResponse.js
+++ b/lib/js/src/rpc/messages/RegisterAppInterfaceResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ReleaseInteriorVehicleDataModule.js
+++ b/lib/js/src/rpc/messages/ReleaseInteriorVehicleDataModule.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ReleaseInteriorVehicleDataModuleResponse.js
+++ b/lib/js/src/rpc/messages/ReleaseInteriorVehicleDataModuleResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ResetGlobalProperties.js
+++ b/lib/js/src/rpc/messages/ResetGlobalProperties.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ResetGlobalPropertiesResponse.js
+++ b/lib/js/src/rpc/messages/ResetGlobalPropertiesResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ScrollableMessage.js
+++ b/lib/js/src/rpc/messages/ScrollableMessage.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ScrollableMessageResponse.js
+++ b/lib/js/src/rpc/messages/ScrollableMessageResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SendHapticData.js
+++ b/lib/js/src/rpc/messages/SendHapticData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SendHapticDataResponse.js
+++ b/lib/js/src/rpc/messages/SendHapticDataResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SendLocation.js
+++ b/lib/js/src/rpc/messages/SendLocation.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SendLocationResponse.js
+++ b/lib/js/src/rpc/messages/SendLocationResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SetAppIcon.js
+++ b/lib/js/src/rpc/messages/SetAppIcon.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SetAppIconResponse.js
+++ b/lib/js/src/rpc/messages/SetAppIconResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SetCloudAppProperties.js
+++ b/lib/js/src/rpc/messages/SetCloudAppProperties.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SetCloudAppPropertiesResponse.js
+++ b/lib/js/src/rpc/messages/SetCloudAppPropertiesResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SetDisplayLayout.js
+++ b/lib/js/src/rpc/messages/SetDisplayLayout.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SetDisplayLayoutResponse.js
+++ b/lib/js/src/rpc/messages/SetDisplayLayoutResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SetGlobalProperties.js
+++ b/lib/js/src/rpc/messages/SetGlobalProperties.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SetGlobalPropertiesResponse.js
+++ b/lib/js/src/rpc/messages/SetGlobalPropertiesResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SetInteriorVehicleData.js
+++ b/lib/js/src/rpc/messages/SetInteriorVehicleData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SetInteriorVehicleDataResponse.js
+++ b/lib/js/src/rpc/messages/SetInteriorVehicleDataResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SetMediaClockTimer.js
+++ b/lib/js/src/rpc/messages/SetMediaClockTimer.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SetMediaClockTimerResponse.js
+++ b/lib/js/src/rpc/messages/SetMediaClockTimerResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/Show.js
+++ b/lib/js/src/rpc/messages/Show.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ShowAppMenu.js
+++ b/lib/js/src/rpc/messages/ShowAppMenu.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ShowAppMenuResponse.js
+++ b/lib/js/src/rpc/messages/ShowAppMenuResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ShowConstantTBT.js
+++ b/lib/js/src/rpc/messages/ShowConstantTBT.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ShowConstantTBTResponse.js
+++ b/lib/js/src/rpc/messages/ShowConstantTBTResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/ShowResponse.js
+++ b/lib/js/src/rpc/messages/ShowResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/Slider.js
+++ b/lib/js/src/rpc/messages/Slider.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SliderResponse.js
+++ b/lib/js/src/rpc/messages/SliderResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/Speak.js
+++ b/lib/js/src/rpc/messages/Speak.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SpeakResponse.js
+++ b/lib/js/src/rpc/messages/SpeakResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SubscribeButton.js
+++ b/lib/js/src/rpc/messages/SubscribeButton.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SubscribeButtonResponse.js
+++ b/lib/js/src/rpc/messages/SubscribeButtonResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SubscribeVehicleData.js
+++ b/lib/js/src/rpc/messages/SubscribeVehicleData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SubscribeVehicleDataResponse.js
+++ b/lib/js/src/rpc/messages/SubscribeVehicleDataResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SubscribeWayPoints.js
+++ b/lib/js/src/rpc/messages/SubscribeWayPoints.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SubscribeWayPointsResponse.js
+++ b/lib/js/src/rpc/messages/SubscribeWayPointsResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SubtleAlert.js
+++ b/lib/js/src/rpc/messages/SubtleAlert.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SubtleAlertResponse.js
+++ b/lib/js/src/rpc/messages/SubtleAlertResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SystemRequest.js
+++ b/lib/js/src/rpc/messages/SystemRequest.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/SystemRequestResponse.js
+++ b/lib/js/src/rpc/messages/SystemRequestResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/UnpublishAppService.js
+++ b/lib/js/src/rpc/messages/UnpublishAppService.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/UnpublishAppServiceResponse.js
+++ b/lib/js/src/rpc/messages/UnpublishAppServiceResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/UnregisterAppInterface.js
+++ b/lib/js/src/rpc/messages/UnregisterAppInterface.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/UnregisterAppInterfaceResponse.js
+++ b/lib/js/src/rpc/messages/UnregisterAppInterfaceResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/UnsubscribeButton.js
+++ b/lib/js/src/rpc/messages/UnsubscribeButton.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/UnsubscribeButtonResponse.js
+++ b/lib/js/src/rpc/messages/UnsubscribeButtonResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/UnsubscribeVehicleData.js
+++ b/lib/js/src/rpc/messages/UnsubscribeVehicleData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/UnsubscribeVehicleDataResponse.js
+++ b/lib/js/src/rpc/messages/UnsubscribeVehicleDataResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/UnsubscribeWayPoints.js
+++ b/lib/js/src/rpc/messages/UnsubscribeWayPoints.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/UnsubscribeWayPointsResponse.js
+++ b/lib/js/src/rpc/messages/UnsubscribeWayPointsResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/UpdateTurnList.js
+++ b/lib/js/src/rpc/messages/UpdateTurnList.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/messages/UpdateTurnListResponse.js
+++ b/lib/js/src/rpc/messages/UpdateTurnListResponse.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/AirbagStatus.js
+++ b/lib/js/src/rpc/structs/AirbagStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/AppCapability.js
+++ b/lib/js/src/rpc/structs/AppCapability.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/AppInfo.js
+++ b/lib/js/src/rpc/structs/AppInfo.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/AppServiceCapability.js
+++ b/lib/js/src/rpc/structs/AppServiceCapability.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/AppServiceData.js
+++ b/lib/js/src/rpc/structs/AppServiceData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/AppServiceManifest.js
+++ b/lib/js/src/rpc/structs/AppServiceManifest.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/AppServiceRecord.js
+++ b/lib/js/src/rpc/structs/AppServiceRecord.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/AppServicesCapabilities.js
+++ b/lib/js/src/rpc/structs/AppServicesCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/AudioControlCapabilities.js
+++ b/lib/js/src/rpc/structs/AudioControlCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/AudioControlData.js
+++ b/lib/js/src/rpc/structs/AudioControlData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/AudioPassThruCapabilities.js
+++ b/lib/js/src/rpc/structs/AudioPassThruCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/BeltStatus.js
+++ b/lib/js/src/rpc/structs/BeltStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/BodyInformation.js
+++ b/lib/js/src/rpc/structs/BodyInformation.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/ButtonCapabilities.js
+++ b/lib/js/src/rpc/structs/ButtonCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/Choice.js
+++ b/lib/js/src/rpc/structs/Choice.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/ClimateControlCapabilities.js
+++ b/lib/js/src/rpc/structs/ClimateControlCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/ClimateControlData.js
+++ b/lib/js/src/rpc/structs/ClimateControlData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/ClimateData.js
+++ b/lib/js/src/rpc/structs/ClimateData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/CloudAppProperties.js
+++ b/lib/js/src/rpc/structs/CloudAppProperties.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/ClusterModeStatus.js
+++ b/lib/js/src/rpc/structs/ClusterModeStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/Coordinate.js
+++ b/lib/js/src/rpc/structs/Coordinate.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/DIDResult.js
+++ b/lib/js/src/rpc/structs/DIDResult.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/DateTime.js
+++ b/lib/js/src/rpc/structs/DateTime.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/DeviceInfo.js
+++ b/lib/js/src/rpc/structs/DeviceInfo.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/DeviceStatus.js
+++ b/lib/js/src/rpc/structs/DeviceStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/DisplayCapabilities.js
+++ b/lib/js/src/rpc/structs/DisplayCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/DisplayCapability.js
+++ b/lib/js/src/rpc/structs/DisplayCapability.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/DoorStatus.js
+++ b/lib/js/src/rpc/structs/DoorStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/DriverDistractionCapability.js
+++ b/lib/js/src/rpc/structs/DriverDistractionCapability.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/DynamicUpdateCapabilities.js
+++ b/lib/js/src/rpc/structs/DynamicUpdateCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/ECallInfo.js
+++ b/lib/js/src/rpc/structs/ECallInfo.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/EmergencyEvent.js
+++ b/lib/js/src/rpc/structs/EmergencyEvent.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/EqualizerSettings.js
+++ b/lib/js/src/rpc/structs/EqualizerSettings.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/FuelRange.js
+++ b/lib/js/src/rpc/structs/FuelRange.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/GPSData.js
+++ b/lib/js/src/rpc/structs/GPSData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/GateStatus.js
+++ b/lib/js/src/rpc/structs/GateStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/GearStatus.js
+++ b/lib/js/src/rpc/structs/GearStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/Grid.js
+++ b/lib/js/src/rpc/structs/Grid.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/HMICapabilities.js
+++ b/lib/js/src/rpc/structs/HMICapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/HMIPermissions.js
+++ b/lib/js/src/rpc/structs/HMIPermissions.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/HMISettingsControlCapabilities.js
+++ b/lib/js/src/rpc/structs/HMISettingsControlCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/HMISettingsControlData.js
+++ b/lib/js/src/rpc/structs/HMISettingsControlData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/HapticRect.js
+++ b/lib/js/src/rpc/structs/HapticRect.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/HeadLampStatus.js
+++ b/lib/js/src/rpc/structs/HeadLampStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/Image.js
+++ b/lib/js/src/rpc/structs/Image.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/ImageField.js
+++ b/lib/js/src/rpc/structs/ImageField.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/ImageResolution.js
+++ b/lib/js/src/rpc/structs/ImageResolution.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/KeyboardCapabilities.js
+++ b/lib/js/src/rpc/structs/KeyboardCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/KeyboardLayoutCapability.js
+++ b/lib/js/src/rpc/structs/KeyboardLayoutCapability.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/KeyboardProperties.js
+++ b/lib/js/src/rpc/structs/KeyboardProperties.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/LightCapabilities.js
+++ b/lib/js/src/rpc/structs/LightCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/LightControlCapabilities.js
+++ b/lib/js/src/rpc/structs/LightControlCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/LightControlData.js
+++ b/lib/js/src/rpc/structs/LightControlData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/LightState.js
+++ b/lib/js/src/rpc/structs/LightState.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/LocationDetails.js
+++ b/lib/js/src/rpc/structs/LocationDetails.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/MassageCushionFirmness.js
+++ b/lib/js/src/rpc/structs/MassageCushionFirmness.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/MassageModeData.js
+++ b/lib/js/src/rpc/structs/MassageModeData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/MediaServiceData.js
+++ b/lib/js/src/rpc/structs/MediaServiceData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/MediaServiceManifest.js
+++ b/lib/js/src/rpc/structs/MediaServiceManifest.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/MenuParams.js
+++ b/lib/js/src/rpc/structs/MenuParams.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/MetadataTags.js
+++ b/lib/js/src/rpc/structs/MetadataTags.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/ModuleData.js
+++ b/lib/js/src/rpc/structs/ModuleData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/ModuleInfo.js
+++ b/lib/js/src/rpc/structs/ModuleInfo.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/MyKey.js
+++ b/lib/js/src/rpc/structs/MyKey.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/NavigationCapability.js
+++ b/lib/js/src/rpc/structs/NavigationCapability.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/NavigationInstruction.js
+++ b/lib/js/src/rpc/structs/NavigationInstruction.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/NavigationServiceData.js
+++ b/lib/js/src/rpc/structs/NavigationServiceData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/NavigationServiceManifest.js
+++ b/lib/js/src/rpc/structs/NavigationServiceManifest.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/OASISAddress.js
+++ b/lib/js/src/rpc/structs/OASISAddress.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/ParameterPermissions.js
+++ b/lib/js/src/rpc/structs/ParameterPermissions.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/PermissionItem.js
+++ b/lib/js/src/rpc/structs/PermissionItem.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/PhoneCapability.js
+++ b/lib/js/src/rpc/structs/PhoneCapability.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/PresetBankCapabilities.js
+++ b/lib/js/src/rpc/structs/PresetBankCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/RGBColor.js
+++ b/lib/js/src/rpc/structs/RGBColor.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/RadioControlCapabilities.js
+++ b/lib/js/src/rpc/structs/RadioControlCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/RadioControlData.js
+++ b/lib/js/src/rpc/structs/RadioControlData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/RdsData.js
+++ b/lib/js/src/rpc/structs/RdsData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/Rectangle.js
+++ b/lib/js/src/rpc/structs/Rectangle.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/RemoteControlCapabilities.js
+++ b/lib/js/src/rpc/structs/RemoteControlCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/RoofStatus.js
+++ b/lib/js/src/rpc/structs/RoofStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/ScreenParams.js
+++ b/lib/js/src/rpc/structs/ScreenParams.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/SdlMsgVersion.js
+++ b/lib/js/src/rpc/structs/SdlMsgVersion.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/SeatControlCapabilities.js
+++ b/lib/js/src/rpc/structs/SeatControlCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/SeatControlData.js
+++ b/lib/js/src/rpc/structs/SeatControlData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/SeatLocation.js
+++ b/lib/js/src/rpc/structs/SeatLocation.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/SeatLocationCapability.js
+++ b/lib/js/src/rpc/structs/SeatLocationCapability.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/SeatMemoryAction.js
+++ b/lib/js/src/rpc/structs/SeatMemoryAction.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/SeatOccupancy.js
+++ b/lib/js/src/rpc/structs/SeatOccupancy.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/SeatStatus.js
+++ b/lib/js/src/rpc/structs/SeatStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/SeekStreamingIndicator.js
+++ b/lib/js/src/rpc/structs/SeekStreamingIndicator.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/SingleTireStatus.js
+++ b/lib/js/src/rpc/structs/SingleTireStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/SisData.js
+++ b/lib/js/src/rpc/structs/SisData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/SoftButton.js
+++ b/lib/js/src/rpc/structs/SoftButton.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/SoftButtonCapabilities.js
+++ b/lib/js/src/rpc/structs/SoftButtonCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/StabilityControlsStatus.js
+++ b/lib/js/src/rpc/structs/StabilityControlsStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/StartTime.js
+++ b/lib/js/src/rpc/structs/StartTime.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/StationIDNumber.js
+++ b/lib/js/src/rpc/structs/StationIDNumber.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/SystemCapability.js
+++ b/lib/js/src/rpc/structs/SystemCapability.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/TTSChunk.js
+++ b/lib/js/src/rpc/structs/TTSChunk.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/Temperature.js
+++ b/lib/js/src/rpc/structs/Temperature.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/TemplateColorScheme.js
+++ b/lib/js/src/rpc/structs/TemplateColorScheme.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/TemplateConfiguration.js
+++ b/lib/js/src/rpc/structs/TemplateConfiguration.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/TextField.js
+++ b/lib/js/src/rpc/structs/TextField.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/TireStatus.js
+++ b/lib/js/src/rpc/structs/TireStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/TouchCoord.js
+++ b/lib/js/src/rpc/structs/TouchCoord.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/TouchEvent.js
+++ b/lib/js/src/rpc/structs/TouchEvent.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/TouchEventCapabilities.js
+++ b/lib/js/src/rpc/structs/TouchEventCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/Turn.js
+++ b/lib/js/src/rpc/structs/Turn.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/VehicleDataResult.js
+++ b/lib/js/src/rpc/structs/VehicleDataResult.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/VehicleType.js
+++ b/lib/js/src/rpc/structs/VehicleType.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/VideoStreamingCapability.js
+++ b/lib/js/src/rpc/structs/VideoStreamingCapability.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/VideoStreamingFormat.js
+++ b/lib/js/src/rpc/structs/VideoStreamingFormat.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/VrHelpItem.js
+++ b/lib/js/src/rpc/structs/VrHelpItem.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/WeatherAlert.js
+++ b/lib/js/src/rpc/structs/WeatherAlert.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/WeatherData.js
+++ b/lib/js/src/rpc/structs/WeatherData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/WeatherServiceData.js
+++ b/lib/js/src/rpc/structs/WeatherServiceData.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/WeatherServiceManifest.js
+++ b/lib/js/src/rpc/structs/WeatherServiceManifest.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/WindowCapability.js
+++ b/lib/js/src/rpc/structs/WindowCapability.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/WindowState.js
+++ b/lib/js/src/rpc/structs/WindowState.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/WindowStatus.js
+++ b/lib/js/src/rpc/structs/WindowStatus.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/lib/js/src/rpc/structs/WindowTypeCapabilities.js
+++ b/lib/js/src/rpc/structs/WindowTypeCapabilities.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /*
-* Copyright (c) 2021, SmartDeviceLink Consortium, Inc.
+* Copyright (c) 2022, SmartDeviceLink Consortium, Inc.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Updates the copyright year in the header of generated RPC files to read 2022. This PR is purely a documentation update and no code changes are included.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
