### PR TITLE
Fix null access error in _PresentAlertOperation

### DIFF
--- a/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
+++ b/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
@@ -455,6 +455,13 @@ class _PresentAlertOperation extends _Task {
      * @returns {Boolean} - True if soft button images are supported, false if not.
      */
     supportsSoftButtonImages () {
+        if (this._currentWindowCapability === null
+            || this._currentWindowCapability === undefined
+            || this._currentWindowCapability.getSoftButtonCapabilities() === null
+            || this._currentWindowCapability.getSoftButtonCapabilities() === undefined
+            || this._currentWindowCapability.getSoftButtonCapabilities().length === 0) {
+            return true; // return true if non-existant soft button capability
+        }
         const softButtonCapabilities = this._currentWindowCapability.getSoftButtonCapabilities()[0];
         return softButtonCapabilities.getImageSupported();
     }


### PR DESCRIPTION
Fixes #526 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

Core version / branch / commit hash / module tested against: 8.0.0
HMI name / version / branch / commit hash / module tested against: 0.11.0

### Summary
Adds checks to the `supportsSoftButtonImages` method in `_PresentAlertOperation`  to avoid accessing properties in potentially null values.
