### PR TITLE
Add warnings for invalid voice command strings

### DIFF
--- a/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
+++ b/lib/js/src/manager/screen/_VoiceCommandManagerBase.js
@@ -179,13 +179,20 @@ class _VoiceCommandManagerBase extends _SubManagerBase {
         const validatedVoiceCommands = voiceCommands.map((voiceCommand) => {
             const voiceCommandStrings = voiceCommand.getVoiceCommands().filter((voiceCommandString) => {
                 // filter out any whitespace characters
-                return voiceCommandString !== null && voiceCommandString !== undefined && voiceCommandString.replace(/\s/g, '').length > 0;
+                const validString = voiceCommandString !== null && voiceCommandString !== undefined && voiceCommandString.replace(/\s/g, '').length > 0;
+                if (!validString) {
+                    console.warn('Empty or whitespace only voice command string: ', voiceCommandString, ', removed from voice command: ', voiceCommand);
+                }
+                return validString;
             });
             // Updates voice command strings array by only adding ones that are not empty(e.g. ', ' ', ...)
             if (voiceCommandStrings.length > 0) {
                 return voiceCommand.setVoiceCommands(voiceCommandStrings);
             }
         }).filter((voiceCommand) => {
+            if (voiceCommand === undefined) {
+                console.warn('A voice command with no valid strings was removed.');
+            }
             return voiceCommand !== undefined;
         });
         return validatedVoiceCommands;


### PR DESCRIPTION
Fixes #529 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

Core version / branch / commit hash / module tested against: 8.0.0
HMI name / version / branch / commit hash / module tested against: 0.11.0

### Summary
Adds warning logs for when a submitted voice string is empty or is blank, and when no valid strings exist for a voice command.