### PR TITLE
Update sdl_javascript_suite/examples/js/hello-sdl/readme.md

### DIFF
--- a/examples/js/hello-sdl/readme.md
+++ b/examples/js/hello-sdl/readme.md
@@ -1,8 +1,8 @@
 ## SDL JavaScript App Startup Instructions
 1) Place the vanilla JS SDL.min.js file into this directory
-1) Request a [Manticore instance](https://smartdevicelink.com/resources/manticore/)
-1) Open two terminal sessions and `cd` both of them into `./examples/js/hello-sdl`
-1) In one terminal session, run `java -jar proxy.jar m.sdl.tools [PORT]`, where `[PORT]` is the one given to you by Manticore
-1) In the other terminal session, run `npm install` then `npm start`.
-1) Your browser should automatically open and the test app should appear on your Manticore UI.
-1) Click on the app in Manticore and observe the series of `Show` RPCs performed. Logs can be seen in your browser's JavaScript console.
+2) Request a [Manticore instance](https://smartdevicelink.com/resources/manticore/)
+3) Open the file `./examples/js/hello-sdl/index.html` in any text editor and find setTransportConfig. setTransportConfig uses the old port number 5050 change it to 2020.
+4) Open a terminal session and `cd` both of them into `./examples/js/hello-sdl`
+5) In the terminal session, run `npm install` then `npm start`.
+6) Your browser should automatically open and the test app should appear on your Manticore UI.
+7) Click on the app in Manticore and observe the series of `Show` RPCs performed. Logs can be seen in your browser's JavaScript console.

--- a/examples/js/hello-sdl/readme.md
+++ b/examples/js/hello-sdl/readme.md
@@ -2,7 +2,7 @@
 1) Place the vanilla JS SDL.min.js file into this directory
 2) Request a [Manticore instance](https://smartdevicelink.com/resources/manticore/).  
 3) Open the file `./examples/js/hello-sdl/index.html` in any text editor and change the transport config's URL and port value to what Manticore's "WS URL" says.
-4) 5) Open a terminal session and `cd` both of them into `./examples/js/hello-sdl`
-6) In the terminal session, run `npm install` then `npm start`.
-7) Your browser should automatically open and the test app should appear on your Manticore UI.
-8) Click on the app in Manticore and observe the series of `Show` RPCs performed. Logs can be seen in your browser's JavaScript console.
+4) Open a terminal session and `cd` both of them into `./examples/js/hello-sdl`
+5) In the terminal session, run `npm install` then `npm start`.
+6) Your browser should automatically open and the test app should appear on your Manticore UI.
+7) Click on the app in Manticore and observe the series of `Show` RPCs performed. Logs can be seen in your browser's JavaScript console.

--- a/examples/js/hello-sdl/readme.md
+++ b/examples/js/hello-sdl/readme.md
@@ -1,8 +1,8 @@
 ## SDL JavaScript App Startup Instructions
 1) Place the vanilla JS SDL.min.js file into this directory
-2) Request a [Manticore instance](https://smartdevicelink.com/resources/manticore/)
-3) Open the file `./examples/js/hello-sdl/index.html` in any text editor and find setTransportConfig. setTransportConfig uses the old port number 5050 change it to 2020.
-4) Open a terminal session and `cd` both of them into `./examples/js/hello-sdl`
-5) In the terminal session, run `npm install` then `npm start`.
-6) Your browser should automatically open and the test app should appear on your Manticore UI.
-7) Click on the app in Manticore and observe the series of `Show` RPCs performed. Logs can be seen in your browser's JavaScript console.
+2) Request a [Manticore instance](https://smartdevicelink.com/resources/manticore/).  
+3) Open the file `./examples/js/hello-sdl/index.html` in any text editor and change the transport config's URL and port value to what Manticore's "WS URL" says.
+4) 5) Open a terminal session and `cd` both of them into `./examples/js/hello-sdl`
+6) In the terminal session, run `npm install` then `npm start`.
+7) Your browser should automatically open and the test app should appear on your Manticore UI.
+8) Click on the app in Manticore and observe the series of `Show` RPCs performed. Logs can be seen in your browser's JavaScript console.


### PR DESCRIPTION
The current application does not require the proxy.jar file to run, the ReadMe.md file has been updated to eliminate the corresponding step (step 4): In one terminal session, run  java -jar proxy.jar m.sdl.tools [PORT], where [PORT] is the one given to you by Manticore.
