### PR TITLE
Vanilla JS readme typo still mentions needing two terminal windows

### DIFF
--- a/examples/js/hello-sdl/readme.md
+++ b/examples/js/hello-sdl/readme.md
@@ -2,7 +2,7 @@
 1) Place the vanilla JS SDL.min.js file into this directory
 2) Request a [Manticore instance](https://smartdevicelink.com/resources/manticore/).  
 3) Open the file `./examples/js/hello-sdl/index.html` in any text editor and change the transport config's URL and port value to what Manticore's "WS URL" says.
-4) Open a terminal session and `cd` both of them into `./examples/js/hello-sdl`
+4) Open a terminal session and `cd` into `./examples/js/hello-sdl`
 5) In the terminal session, run `npm install` then `npm start`.
 6) Your browser should automatically open and the test app should appear on your Manticore UI.
 7) Click on the app in Manticore and observe the series of `Show` RPCs performed. Logs can be seen in your browser's JavaScript console.


### PR DESCRIPTION
Fixes #537 

### Risk
This PR makes **no** API changes.

### Testing Plan
- [X] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [X] I have verified that this PR passes lint validation
- [X] I have run the unit tests with this PR
- [X] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
The old instructions in the vanilla JS example app readme involved having 2 terminal windows open where one of them was running the proxy.jar file. The proxy.jar file is no longer required to run the example app, so it was removed from the instructions, but the readme still mentions having 2 terminal windows open which is confusing.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
