### PR TITLE
Do not clone _imageRPC with SdlArtwork

### DIFF
--- a/lib/js/src/manager/file/filetypes/SdlArtwork.js
+++ b/lib/js/src/manager/file/filetypes/SdlArtwork.js
@@ -125,9 +125,9 @@ class SdlArtwork extends SdlFile {
     clone () {
         const clonedParams = Object.assign({}, this); // shallow copy
 
-        if (clonedParams._imageRPC !== null) {
-            clonedParams._imageRPC = Object.assign(new Image(), clonedParams._imageRPC);
-        }
+        // do not clone the _imageRPC parameter. let getImageRPC regenerate the property if the manager needs it
+        delete clonedParams._imageRPC;
+
         return Object.assign(new SdlArtwork(), clonedParams);
     }
 }


### PR DESCRIPTION
Fixes #546 

### Risk
This PR makes minor API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

Tested on Manticore for SDL Core v8.1.0

### Summary
When cloning an SdlArtwork instance, do not clone the cached _imageRPC object with it. This prevents a case where the user changes the file name but the cached object does not update and the T&G manager uses that outdated information. 