### PR TITLE
Fix T&G issues with updating state rapidly

### DIFF
--- a/lib/js/src/manager/screen/_TextAndGraphicManagerBase.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicManagerBase.js
@@ -66,7 +66,6 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
         this._textField4Type = null;
         this._isDirty = false;
         this._updateOperation = null;
-        this._currentOperationListener = null;
         this._templateConfiguration = null;
 
         this._handleDisplayCapabilityUpdates();
@@ -107,7 +106,6 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
         this._textField4Type = null;
         this._isDirty = false;
         this._updateOperation = null;
-        this._currentOperationListener = null;
 
         this._handleDisplayCapabilityUpdates();
         this._handleTaskQueue();
@@ -124,7 +122,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
                 resolve(false);
             }
             if (this._isDirty) {
-                this._sdlUpdate(true, resolve);
+                this._sdlUpdate(resolve);
             } else {
                 resolve(true);
             }
@@ -134,12 +132,9 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     /**
      * Determines what needs to be done to send a valid Show method
      * @private
-     * @param {Boolean} supersedePreviousOperations - Whether this update should have priority over previous updates
      * @param {function} listener - A function to invoke when the update task is complete once it runs
      */
-    _sdlUpdate (supersedePreviousOperations, listener) {
-        this._currentOperationListener = listener;
-
+    _sdlUpdate (listener) {
         const currentScreenDataUpdateListener = (asyncListener) => {
             asyncListener().then((newScreenData) => {
                 if (newScreenData !== null) {
@@ -147,12 +142,13 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
                     this._updatePendingOperationsWithNewScreenData();
                 }
             }).catch((errorState) => {
+                this._resetFieldsToCurrentScreenData();
                 this._updatePendingOperationsWithFailedScreenState(errorState);
             });
         };
 
         this._updateOperation = new _TextAndGraphicUpdateOperation(this._lifecycleManager, this._fileManager, this._defaultMainWindowCapability,
-            this._currentScreenData, this._currentState(), this._currentOperationListener, currentScreenDataUpdateListener.bind(this));
+            this._currentScreenData, this._currentState(), listener, currentScreenDataUpdateListener.bind(this));
         this._addTask(this._updateOperation);
     }
 
@@ -187,9 +183,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
             if (!(task instanceof _TextAndGraphicUpdateOperation)) {
                 continue;
             }
-            if (errorState instanceof _TextAndGraphicState) { // check if a _TextAndGraphicState was passed in instead of an error object
-                task._updateTargetStateWithErrorState(errorState);
-            }
+            task._updateTargetStateWithErrorState(errorState);
         }
     }
 
@@ -239,7 +233,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextAlignment (textAlignment) {
         this._textAlignment = textAlignment;
         if (!this._batchingUpdates) {
-            this._sdlUpdate(true, null);
+            this._sdlUpdate(null);
         } else {
             this._isDirty = true;
         }
@@ -262,7 +256,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setMediaTrackTextField (mediaTrackTextField) {
         this._mediaTrackTextField = mediaTrackTextField;
         if (!this._batchingUpdates) {
-            this._sdlUpdate(true, null);
+            this._sdlUpdate(null);
         } else {
             this._isDirty = true;
         }
@@ -285,7 +279,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField1 (textField1) {
         this._textField1 = textField1;
         if (!this._batchingUpdates) {
-            this._sdlUpdate(true, null);
+            this._sdlUpdate(null);
         } else {
             this._isDirty = true;
         }
@@ -308,7 +302,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField2 (textField2) {
         this._textField2 = textField2;
         if (!this._batchingUpdates) {
-            this._sdlUpdate(true, null);
+            this._sdlUpdate(null);
         } else {
             this._isDirty = true;
         }
@@ -331,7 +325,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField3 (textField3) {
         this._textField3 = textField3;
         if (!this._batchingUpdates) {
-            this._sdlUpdate(true, null);
+            this._sdlUpdate(null);
         } else {
             this._isDirty = true;
         }
@@ -354,7 +348,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField4 (textField4) {
         this._textField4 = textField4;
         if (!this._batchingUpdates) {
-            this._sdlUpdate(true, null);
+            this._sdlUpdate(null);
         } else {
             this._isDirty = true;
         }
@@ -377,7 +371,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField1Type (textField1Type) {
         this._textField1Type = textField1Type;
         if (!this._batchingUpdates) {
-            this._sdlUpdate(true, null);
+            this._sdlUpdate(null);
         } else {
             this._isDirty = true;
         }
@@ -400,7 +394,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField2Type (textField2Type) {
         this._textField2Type = textField2Type;
         if (!this._batchingUpdates) {
-            this._sdlUpdate(true, null);
+            this._sdlUpdate(null);
         } else {
             this._isDirty = true;
         }
@@ -423,7 +417,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField3Type (textField3Type) {
         this._textField3Type = textField3Type;
         if (!this._batchingUpdates) {
-            this._sdlUpdate(true, null);
+            this._sdlUpdate(null);
         } else {
             this._isDirty = true;
         }
@@ -446,7 +440,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTextField4Type (textField4Type) {
         this._textField4Type = textField4Type;
         if (!this._batchingUpdates) {
-            this._sdlUpdate(true, null);
+            this._sdlUpdate(null);
         } else {
             this._isDirty = true;
         }
@@ -469,7 +463,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setTitle (title) {
         this._title = title;
         if (!this._batchingUpdates) {
-            this._sdlUpdate(true, null);
+            this._sdlUpdate(null);
         } else {
             this._isDirty = true;
         }
@@ -492,7 +486,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setPrimaryGraphic (primaryGraphic) {
         this._primaryGraphic = primaryGraphic;
         if (!this._batchingUpdates) {
-            this._sdlUpdate(true, null);
+            this._sdlUpdate(null);
         } else {
             this._isDirty = true;
         }
@@ -515,7 +509,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     setSecondaryGraphic (secondaryGraphic) {
         this._secondaryGraphic = secondaryGraphic;
         if (!this._batchingUpdates) {
-            this._sdlUpdate(true, null);
+            this._sdlUpdate(null);
         } else {
             this._isDirty = true;
         }
@@ -538,7 +532,7 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     changeLayout (templateConfiguration, listener) {
         this.setTemplateConfiguration(templateConfiguration);
         if (!this._batchingUpdates) {
-            this._sdlUpdate(true, listener);
+            this._sdlUpdate(listener);
         } else {
             this._isDirty = true;
         }

--- a/lib/js/src/manager/screen/_TextAndGraphicManagerBase.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicManagerBase.js
@@ -31,7 +31,6 @@
 */
 
 import { _SubManagerBase } from '../_SubManagerBase.js';
-import { _Task } from '../_Task.js';
 import { _TextAndGraphicUpdateOperation } from './_TextAndGraphicUpdateOperation.js';
 import { _TextAndGraphicState } from './_TextAndGraphicState.js';
 
@@ -139,17 +138,6 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
      * @param {function} listener - A function to invoke when the update task is complete once it runs
      */
     _sdlUpdate (supersedePreviousOperations, listener) {
-        if (this._updateOperation !== null && this._updateOperation.getState() === _Task.READY && supersedePreviousOperations) {
-            this._updateOperation.switchStates(_Task.CANCELED);
-            if (typeof this._currentOperationListener === 'function') {
-                this._currentOperationListener(false);
-            }
-        }
-
-        if (this._updateOperation !== null && this._updateOperation.getState() === _Task.IN_PROGRESS && supersedePreviousOperations) {
-            this._updateOperation.switchStates(_Task.CANCELED);
-        }
-
         this._currentOperationListener = listener;
 
         const currentScreenDataUpdateListener = (asyncListener) => {
@@ -158,8 +146,8 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
                     this._currentScreenData = newScreenData;
                     this._updatePendingOperationsWithNewScreenData();
                 }
-            }).catch((err) => {
-                this._resetFieldsToCurrentScreenData();
+            }).catch((errorState) => {
+                this._updatePendingOperationsWithFailedScreenState(errorState);
             });
         };
 
@@ -190,10 +178,26 @@ class _TextAndGraphicManagerBase extends _SubManagerBase {
     }
 
     /**
+     * Updates all pending tasks in the queue with the failed screen state
+     * @param {_TextAndGraphicState} errorState - The _TextAndGraphicState when the error occured
+     * @private
+     */
+    _updatePendingOperationsWithFailedScreenState (errorState) {
+        for (const task of this._getTasks()) {
+            if (!(task instanceof _TextAndGraphicUpdateOperation)) {
+                continue;
+            }
+            if (errorState instanceof _TextAndGraphicState) { // check if a _TextAndGraphicState was passed in instead of an error object
+                task._updateTargetStateWithErrorState(errorState);
+            }
+        }
+    }
+
+    /**
      * Updates all pending tasks in the queue with the current screen data
      */
     _updatePendingOperationsWithNewScreenData () {
-        for (const task in this._getTasks()) {
+        for (const task of this._getTasks()) {
             if (!(task instanceof _TextAndGraphicUpdateOperation)) {
                 continue;
             }

--- a/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
@@ -87,7 +87,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
         this._fullShow = this._assembleLayout(this._fullShow);
 
         if (this._showRpcSupportsTemplateConfiguration()) {
-            this._updateGraphicsAndShow(this._fullShow);
+            await this._updateGraphicsAndShow(this._fullShow);
         } else {
             if (this._shouldUpdateTemplateConfig()) {
                 const success = await this._sendSetDisplayLayoutWithTemplateConfiguration(this._updatedState.getTemplateConfiguration());
@@ -96,9 +96,9 @@ class _TextAndGraphicUpdateOperation extends _Task {
                     this._finishOperation(false);
                     return;
                 }
-                this._updateGraphicsAndShow(this._fullShow);
+                await this._updateGraphicsAndShow(this._fullShow);
             } else {
-                this._updateGraphicsAndShow(this._fullShow);
+                await this._updateGraphicsAndShow(this._fullShow);
             }
         }
     }
@@ -146,7 +146,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
             } else {
                 console.info('Text and Graphic Show failed');
                 this._currentScreenDataUpdateListener(async () => {
-                    throw new Error('Text and Graphic Show failed');
+                    throw this._updatedState; // send the errored state back to the manager
                 });
             }
             return response.getSuccess();
@@ -859,6 +859,59 @@ class _TextAndGraphicUpdateOperation extends _Task {
             this._listener(success);
         }
         this.onFinished();
+    }
+
+    /**
+     * Applies changes to the _TextAndGraphicState with that of the error state
+     * @private
+     * @param {_TextAndGraphicState} errorState - The _TextAndGraphicState when the error occured
+     */
+    _updateTargetStateWithErrorState (errorState) {
+        if (errorState.getTextField1() === this._updatedState.getTextField1()) {
+            this._updatedState.setTextField1(this._currentScreenData.getTextField1());
+        }
+        if (errorState.getTextField2() === this._updatedState.getTextField2()) {
+            this._updatedState.setTextField2(this._currentScreenData.getTextField2());
+        }
+        if (errorState.getTextField3() === this._updatedState.getTextField3()) {
+            this._updatedState.setTextField3(this._currentScreenData.getTextField3());
+        }
+        if (errorState.getTextField4() === this._updatedState.getTextField4()) {
+            this._updatedState.setTextField4(this._currentScreenData.getTextField4());
+        }
+        if (errorState.getMediaTrackTextField() === this._updatedState.getMediaTrackTextField()) {
+            this._updatedState.setMediaTrackTextField(this._currentScreenData.getMediaTrackTextField());
+        }
+        if (errorState.getTitle() === this._updatedState.getTitle()) {
+            this._updatedState.setTitle(this._currentScreenData.getTitle());
+        }
+        if ((errorState.getPrimaryGraphic() === null && this._updatedState.getPrimaryGraphic() === null)
+            || (errorState.getPrimaryGraphic() !== null && errorState.getPrimaryGraphic().equals(this._updatedState.getPrimaryGraphic()))) { // for safe null check
+            this._updatedState.setPrimaryGraphic(this._currentScreenData.getPrimaryGraphic());
+        }
+        if ((errorState.getSecondaryGraphic() === null && this._updatedState.getSecondaryGraphic() === null)
+            || (errorState.getSecondaryGraphic() !== null && errorState.getSecondaryGraphic().equals(this._updatedState.getSecondaryGraphic()))) { // for safe null check
+            this._updatedState.setSecondaryGraphic(this._currentScreenData.getSecondaryGraphic());
+        }
+        if (errorState.getTextAlignment() === this._updatedState.getTextAlignment()) {
+            this._updatedState.setTextAlignment(this._currentScreenData.getTextAlignment());
+        }
+        if (errorState.getTextField1Type() === this._updatedState.getTextField1Type()) {
+            this._updatedState.setTextField1Type(this._currentScreenData.getTextField1Type());
+        }
+        if (errorState.getTextField2Type() === this._updatedState.getTextField2Type()) {
+            this._updatedState.setTextField2Type(this._currentScreenData.getTextField2Type());
+        }
+        if (errorState.getTextField3Type() === this._updatedState.getTextField3Type()) {
+            this._updatedState.setTextField3Type(this._currentScreenData.getTextField3Type());
+        }
+        if (errorState.getTextField4Type() === this._updatedState.getTextField4Type()) {
+            this._updatedState.setTextField4Type(this._currentScreenData.getTextField4Type());
+        }
+        if ((errorState.getTemplateConfiguration() === null && this._updatedState.getTemplateConfiguration() === null)
+            || (errorState.getTemplateConfiguration() !== null && errorState.getTemplateConfiguration().getParameters() === this._updatedState.getTemplateConfiguration().getParameters())) { // for safe null check
+            this._updatedState.setTemplateConfiguration(this._currentScreenData.getTemplateConfiguration());
+        }
     }
 }
 

--- a/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
@@ -153,7 +153,7 @@ class _TextAndGraphicUpdateOperation extends _Task {
         } else {
             console.info('LifecycleManager is null, Text and Graphic update failed');
             this._currentScreenDataUpdateListener(async () => {
-                throw new Error('LifecycleManager is null, Text and Graphic update failed');
+                throw this._updatedState; // send the errored state back to the manager
             });
             this._finishOperation(false);
             return;
@@ -176,14 +176,14 @@ class _TextAndGraphicUpdateOperation extends _Task {
             } else {
                 console.info('Text and Graphic SetDisplayLayout failed');
                 this._currentScreenDataUpdateListener(async () => {
-                    throw new Error('Text and Graphic SetDisplayLayout failed');
+                    throw this._updatedState; // send the errored state back to the manager
                 });
             }
             return response.getSuccess();
         } else {
             console.info('LifecycleManager is null, Text and Graphic update failed');
             this._currentScreenDataUpdateListener(async () => {
-                throw new Error('LifecycleManager is null, Text and Graphic update failed');
+                throw this._updatedState; // send the errored state back to the manager
             });
             this._finishOperation(false);
             return;
@@ -885,14 +885,21 @@ class _TextAndGraphicUpdateOperation extends _Task {
         if (errorState.getTitle() === this._updatedState.getTitle()) {
             this._updatedState.setTitle(this._currentScreenData.getTitle());
         }
-        if ((errorState.getPrimaryGraphic() === null && this._updatedState.getPrimaryGraphic() === null)
-            || (errorState.getPrimaryGraphic() !== null && errorState.getPrimaryGraphic().equals(this._updatedState.getPrimaryGraphic()))) { // for safe null check
+
+        const errorPrimary = errorState.getPrimaryGraphic();
+        const updatedPrimary = this._updatedState.getPrimaryGraphic();
+        if ((errorPrimary === null && updatedPrimary === null)
+            || (errorPrimary !== null && errorPrimary.equals(updatedPrimary) && errorPrimary.isTemplateImage() === updatedPrimary.isTemplateImage())) { // for safe null check
             this._updatedState.setPrimaryGraphic(this._currentScreenData.getPrimaryGraphic());
         }
-        if ((errorState.getSecondaryGraphic() === null && this._updatedState.getSecondaryGraphic() === null)
-            || (errorState.getSecondaryGraphic() !== null && errorState.getSecondaryGraphic().equals(this._updatedState.getSecondaryGraphic()))) { // for safe null check
-            this._updatedState.setSecondaryGraphic(this._currentScreenData.getSecondaryGraphic());
+
+        const errorSecondary = errorState.getSecondaryGraphic();
+        const updatedSecondary = this._updatedState.getSecondaryGraphic();
+        if ((errorSecondary === null && updatedSecondary === null)
+            || (errorSecondary !== null && errorSecondary.equals(updatedSecondary) && errorSecondary.isTemplateImage() === updatedSecondary.isTemplateImage())) { // for safe null check
+            this._updatedState.setPrimaryGraphic(this._currentScreenData.getPrimaryGraphic());
         }
+
         if (errorState.getTextAlignment() === this._updatedState.getTextAlignment()) {
             this._updatedState.setTextAlignment(this._currentScreenData.getTextAlignment());
         }


### PR DESCRIPTION
Fixes #554 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Add tests for the new _updateTargetStateWithErrorState method

### Summary
When sending updates of invalid data followed by valid data to the T&G manager, the valid data will not be thrown out with the invalid data.

##### Bug Fixes
Resolved an issue with _updatePendingOperationsWithNewScreenData where the wrong identifier was used in the for loop for looping over tasks.

Also fixed _TextAndGraphicUpdateOperation to properly await on sending shows so that the task does not immediately complete.

Fixed variables in test returning undefined due to non-existent SDL.rpc.enums.MetadataType.MEDIA_TITLE value.