### PR TITLE
Update T&G current screen data with template config

### DIFF
--- a/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
+++ b/lib/js/src/manager/screen/_TextAndGraphicUpdateOperation.js
@@ -665,6 +665,9 @@ class _TextAndGraphicUpdateOperation extends _Task {
         if (show.getSecondaryGraphic() !== null && show.getSecondaryGraphic() !== undefined) {
             this._currentScreenData.setSecondaryGraphic(this._updatedState.getSecondaryGraphic());
         }
+        if (show.getTemplateConfiguration() !== null && show.getTemplateConfiguration() !== undefined) {
+            this._currentScreenData.setTemplateConfiguration(this._updatedState.getTemplateConfiguration());
+        }
         if (typeof this._currentScreenDataUpdateListener === 'function') {
             this._currentScreenDataUpdateListener(async () => {
                 return this._currentScreenData;

--- a/tests/managers/screen/TextAndGraphicUpdateOperationTests.js
+++ b/tests/managers/screen/TextAndGraphicUpdateOperationTests.js
@@ -29,6 +29,7 @@ module.exports = function (appClient) {
         let textField4Type;
         let textAlignment;
         let configuration;
+        let configurationOld;
         let currentScreenData;
         let currentScreenDataUpdatedListener;
         let defaultMainWindowCapability;
@@ -56,6 +57,7 @@ module.exports = function (appClient) {
             textField4Type = SDL.rpc.enums.MetadataType.MEDIA_TITLE;
             textAlignment = SDL.rpc.enums.TextAlignment.CENTERED;
             configuration = new SDL.rpc.structs.TemplateConfiguration().setTemplate(SDL.rpc.enums.PredefinedLayout.GRAPHIC_WITH_TEXT);
+            configurationOld = new SDL.rpc.structs.TemplateConfiguration().setTemplate(SDL.rpc.enums.PredefinedLayout.TEXT_WITH_GRAPHIC);
             currentScreenData = new SDL.manager.screen._TextAndGraphicState();
             currentScreenData.setTextField1('Old');
             currentScreenData.setTextField2('Text');
@@ -63,7 +65,7 @@ module.exports = function (appClient) {
             currentScreenData.setTextField4('Important');
             currentScreenData.setPrimaryGraphic(testArtwork1);
             currentScreenData.setSecondaryGraphic(testArtwork2);
-            currentScreenData.setTemplateConfiguration(configuration);
+            currentScreenData.setTemplateConfiguration(configurationOld);
             currentScreenDataUpdatedListener = (asyncListener) => {
                 asyncListener().then(() => {}).catch(() => {});
             };
@@ -925,7 +927,6 @@ module.exports = function (appClient) {
                 mediaTrackField, title, testArtwork1, testArtwork2, textAlignment, textField1Type, textField2Type, textField3Type, textField4Type, configuration);
             textAndGraphicUpdateOperation = new SDL.manager.screen._TextAndGraphicUpdateOperation(lifecycleManager, fileManager, defaultMainWindowCapability, currentScreenData, textsAndGraphicsState, listener, currentScreenDataUpdatedListener);
             await textAndGraphicUpdateOperation._start();
-            Validator.assertEquals(textAndGraphicUpdateOperation._getCurrentScreenData().getTemplateConfiguration().getParameters(), configuration.getParameters());
 
             // Verifies that uploadArtworks does not get called because a sendShow failed with text and layout change
             Validator.assertTrue(!wasUploadArtworksCalled);


### PR DESCRIPTION
Fixes #559 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
When sending a show and updating the internal state of the text and graphic manager, remember the template configuration that was set.