### PR TITLE
Apply fix to alert icon not uploading

### DIFF
--- a/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
+++ b/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
@@ -233,15 +233,13 @@ class _PresentAlertOperation extends _Task {
                 console.log('All alert images uploaded');
             }
 
-            const artworkResults = [];
+            const artworkNamesSuccessfullyUploaded = [];
             for (let index = 0; index < successes.length; index++) {
-                artworkResults.push({
-                    artwork: artworksToBeUploaded[index],
-                    success: successes[index],
-                });
-            }
             // only keep artworks that have been uploaded successfully by the file manager
-            const artworkNamesSuccessfullyUploaded = artworkResults.filter(result => result.success).map(result => result.artwork.getName());
+                if (successes[index]) {
+                    artworkNamesSuccessfullyUploaded.push(artworksToBeUploaded[index].getName());
+                }
+            }
             if (artworkNamesSuccessfullyUploaded.includes(this._alertView.getIcon().getName())) {
                 this._alertIconUploaded = true;
             }

--- a/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
+++ b/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
@@ -235,7 +235,7 @@ class _PresentAlertOperation extends _Task {
 
             const artworkNamesSuccessfullyUploaded = [];
             for (let index = 0; index < successes.length; index++) {
-            // only keep artworks that have been uploaded successfully by the file manager
+                // only keep artworks that have been uploaded successfully by the file manager
                 if (successes[index]) {
                     artworkNamesSuccessfullyUploaded.push(artworksToBeUploaded[index].getName());
                 }

--- a/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
+++ b/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
@@ -63,6 +63,7 @@ class _PresentAlertOperation extends _Task {
         this._listener = listener;
         this._isAlertPresented = false;
         this._alertSoftButtonClearListener = alertSoftButtonClearListener;
+        this._uploadedImageNames = new Set(); // stores a set of image name strings
 
         this._alertView.canceledListener = () => {
             this.cancelAlert();
@@ -192,15 +193,25 @@ class _PresentAlertOperation extends _Task {
     async uploadImages (listener) {
         const artworksToBeUploaded = [];
 
-        if (this.supportsAlertIcon() && this._fileManager !== null && this._fileManager.fileNeedsUpload(this._alertView.getIcon())) {
-            artworksToBeUploaded.push(this._alertView.getIcon());
+        if (this.supportsAlertIcon() && this._alertView.getIcon() !== null && this._alertView.getIcon() !== undefined) {
+            if (this._fileManager.fileNeedsUpload(this._alertView.getIcon())) {
+                // If the file is not uploaded, attempt to upload it
+                artworksToBeUploaded.push(this._alertView.getIcon());
+            } else if (this._fileManager.hasUploadedFile(this._alertView.getIcon()) || this._alertView.getIcon().isStaticIcon()) {
+                // If the file is already uploaded, add it to the uploaded set so we can show it
+                this._uploadedImageNames.add(this._alertView.getIcon().getName());
+            }
         }
 
         if (this._alertView.getSoftButtons() !== null && this._alertView.getSoftButtons() !== undefined) {
             for (let index = 0; index < this._getSoftButtonCount(); index++) {
-                const object = this._alertView.getSoftButtons()[index];
-                if (this.supportsSoftButtonImages() && object.getCurrentState() !== null && object.getCurrentState() !== undefined && this._fileManager !== null && this._fileManager.fileNeedsUpload(object.getCurrentState().getArtwork())) {
-                    artworksToBeUploaded.push(object.getCurrentState().getArtwork());
+                const objectState = this._alertView.getSoftButtons()[index].getCurrentState();
+                if (this.supportsSoftButtonImages()) {
+                    if (objectState !== null && objectState !== undefined && this._fileManager !== null && this._fileManager.fileNeedsUpload(objectState.getArtwork())) {
+                        artworksToBeUploaded.push(objectState.getArtwork());
+                    } else if (this._fileManager.hasUploadedFile(objectState.getArtwork()) || objectState.getArtwork().isStaticIcon()) {
+                        this._uploadedImageNames.add(objectState.getArtwork().getName());
+                    }
                 }
             }
         }
@@ -227,6 +238,9 @@ class _PresentAlertOperation extends _Task {
             } else {
                 console.log('All alert images uploaded');
             }
+            artworksToBeUploaded.forEach(artwork => {
+                this._uploadedImageNames.add(artwork.getName());
+            });
             listener(true);
             return;
         }
@@ -301,7 +315,7 @@ class _PresentAlertOperation extends _Task {
         alert = this.assembleAlertText(alert);
         alert.setDuration(this._alertView.getTimeout() * 1000);
 
-        if (this._alertView.getIcon() !== null && this._alertView.getIcon() !== undefined && this.supportsAlertIcon() && !this._fileManager.hasUploadedFile(this._alertView.getIcon())) {
+        if (this._alertView.getIcon() !== null && this._alertView.getIcon() !== undefined && this._uploadedImageNames.has(this._alertView.getIcon().getName())) {
             alert.setAlertIcon(this._alertView.getIcon().getImageRPC());
         }
 

--- a/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
+++ b/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
@@ -206,8 +206,8 @@ class _PresentAlertOperation extends _Task {
         if (this._alertView.getSoftButtons() !== null && this._alertView.getSoftButtons() !== undefined) {
             for (let index = 0; index < this._getSoftButtonCount(); index++) {
                 const objectState = this._alertView.getSoftButtons()[index].getCurrentState();
-                if (this.supportsSoftButtonImages()) {
-                    if (objectState !== null && objectState !== undefined && this._fileManager !== null && this._fileManager.fileNeedsUpload(objectState.getArtwork())) {
+                if (this.supportsSoftButtonImages() && objectState !== null && objectState !== undefined && objectState.getArtwork() !== null && objectState.getArtwork() !== undefined) {
+                    if (this._fileManager !== null && this._fileManager.fileNeedsUpload(objectState.getArtwork())) {
                         artworksToBeUploaded.push(objectState.getArtwork());
                     } else if (this._fileManager.hasUploadedFile(objectState.getArtwork()) || objectState.getArtwork().isStaticIcon()) {
                         this._uploadedImageNames.add(objectState.getArtwork().getName());

--- a/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
+++ b/lib/js/src/manager/screen/utils/_PresentAlertOperation.js
@@ -63,7 +63,7 @@ class _PresentAlertOperation extends _Task {
         this._listener = listener;
         this._isAlertPresented = false;
         this._alertSoftButtonClearListener = alertSoftButtonClearListener;
-        this._uploadedImageNames = new Set(); // stores a set of image name strings
+        this._alertIconUploaded = false;
 
         this._alertView.canceledListener = () => {
             this.cancelAlert();
@@ -169,7 +169,7 @@ class _PresentAlertOperation extends _Task {
 
         console.log('Uploading audio files for alert');
 
-        if (this._fileManager !== null || this._fileManager !== undefined) {
+        if (this._fileManager !== null) {
             const successes = await this._fileManager.uploadFiles(filesToBeUploaded);
 
             if (this.getState() === _Task.CANCELED) {
@@ -193,25 +193,19 @@ class _PresentAlertOperation extends _Task {
     async uploadImages (listener) {
         const artworksToBeUploaded = [];
 
-        if (this.supportsAlertIcon() && this._alertView.getIcon() !== null && this._alertView.getIcon() !== undefined) {
+        if (this.supportsAlertIcon() && this._alertView.getIcon() !== null && this._alertView.getIcon() !== undefined && this._fileManager !== null) {
             if (this._fileManager.fileNeedsUpload(this._alertView.getIcon())) {
-                // If the file is not uploaded, attempt to upload it
                 artworksToBeUploaded.push(this._alertView.getIcon());
             } else if (this._fileManager.hasUploadedFile(this._alertView.getIcon()) || this._alertView.getIcon().isStaticIcon()) {
-                // If the file is already uploaded, add it to the uploaded set so we can show it
-                this._uploadedImageNames.add(this._alertView.getIcon().getName());
+                this._alertIconUploaded = true;
             }
         }
 
         if (this._alertView.getSoftButtons() !== null && this._alertView.getSoftButtons() !== undefined) {
             for (let index = 0; index < this._getSoftButtonCount(); index++) {
                 const objectState = this._alertView.getSoftButtons()[index].getCurrentState();
-                if (this.supportsSoftButtonImages() && objectState !== null && objectState !== undefined && objectState.getArtwork() !== null && objectState.getArtwork() !== undefined) {
-                    if (this._fileManager !== null && this._fileManager.fileNeedsUpload(objectState.getArtwork())) {
-                        artworksToBeUploaded.push(objectState.getArtwork());
-                    } else if (this._fileManager.hasUploadedFile(objectState.getArtwork()) || objectState.getArtwork().isStaticIcon()) {
-                        this._uploadedImageNames.add(objectState.getArtwork().getName());
-                    }
+                if (this.supportsSoftButtonImages() && objectState !== null && objectState !== undefined && this._fileManager !== null && this._fileManager.fileNeedsUpload(objectState.getArtwork())) {
+                    artworksToBeUploaded.push(objectState.getArtwork());
                 }
             }
         }
@@ -224,7 +218,7 @@ class _PresentAlertOperation extends _Task {
 
         console.log('Uploading images for alert');
 
-        if (this._fileManager !== null && this._fileManager !== undefined) {
+        if (this._fileManager !== null) {
             const successes = await this._fileManager.uploadArtworks(artworksToBeUploaded);
             if (this.getState() === _Task.CANCELED) {
                 console.log('Operation canceled');
@@ -238,9 +232,19 @@ class _PresentAlertOperation extends _Task {
             } else {
                 console.log('All alert images uploaded');
             }
-            artworksToBeUploaded.forEach(artwork => {
-                this._uploadedImageNames.add(artwork.getName());
-            });
+
+            const artworkResults = [];
+            for (let index = 0; index < successes.length; index++) {
+                artworkResults.push({
+                    artwork: artworksToBeUploaded[index],
+                    success: successes[index],
+                });
+            }
+            // only keep artworks that have been uploaded successfully by the file manager
+            const artworkNamesSuccessfullyUploaded = artworkResults.filter(result => result.success).map(result => result.artwork.getName());
+            if (artworkNamesSuccessfullyUploaded.includes(this._alertView.getIcon().getName())) {
+                this._alertIconUploaded = true;
+            }
             listener(true);
             return;
         }
@@ -315,7 +319,7 @@ class _PresentAlertOperation extends _Task {
         alert = this.assembleAlertText(alert);
         alert.setDuration(this._alertView.getTimeout() * 1000);
 
-        if (this._alertView.getIcon() !== null && this._alertView.getIcon() !== undefined && this._uploadedImageNames.has(this._alertView.getIcon().getName())) {
+        if (this._alertIconUploaded) {
             alert.setAlertIcon(this._alertView.getIcon().getImageRPC());
         }
 

--- a/tests/managers/screen/PresentAlertOperationTests.js
+++ b/tests/managers/screen/PresentAlertOperationTests.js
@@ -23,6 +23,7 @@ module.exports = function (appClient) {
             speechCapabilities,
             alertCompletionListener,
             alertSoftButtonClearListener;
+
         /**
          * Gets the windowCapability
          * @param {Number} numberOfAlertFields - number of lines
@@ -280,6 +281,17 @@ module.exports = function (appClient) {
             await presentAlertOperation._start();
             Validator.assertTrue(callback.notCalled);
             stub.restore();
+        });
+
+        it('testNoImageSetOnFailedUpload', async function () {
+            const alertRpc = presentAlertOperation.alertRpc();
+            Validator.assertNull(alertRpc.getAlertIcon());
+        });
+
+        it('testImageSetOnSuccessfulUpload', async function () {
+            presentAlertOperation._uploadedImageNames.add(alertView.getIcon().getName());
+            const alertRpc = presentAlertOperation.alertRpc();
+            Validator.assertEquals(alertRpc.getAlertIcon().getValueParam(), alertView.getIcon().getName());
         });
     });
 };


### PR DESCRIPTION
Fixes #558 

### Risk
This PR makes no API changes.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have verified that this PR passes lint validation
- [x] I have run the unit tests with this PR
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Unit Tests
Tests the Alert RPC generation when an AlertView has an icon

### Summary
_PresentAlertOperation now keeps track of uploaded artwork names and uses it to check whether to attach the AlertView icon to the Alert RPC.